### PR TITLE
fix(#71): remove unused wrong flag parsing logic

### DIFF
--- a/AnimeStudio/BlbFile.cs
+++ b/AnimeStudio/BlbFile.cs
@@ -109,19 +109,9 @@ namespace AnimeStudio
                     size = reader.ReadInt32()
                 });
 
-                var pos = reader.Position;
-                reader.Position = flagInfoOffset;
-                var flag = reader.ReadUInt32();
-                if (i >= 0x20)
-                {
-                    flag = reader.ReadUInt32();
-                }
-                m_DirectoryInfo[i].flags = (uint)(flag & (1 << i)) * 4;
-                reader.Position = pos;
-
                 var pathOffset = reader.Position + reader.ReadInt64();
 
-                pos = reader.Position;
+                var pos = reader.Position;
                 reader.Position = pathOffset;
                 m_DirectoryInfo[i].path = reader.ReadStringToNull();
                 reader.Position = pos;

--- a/AnimeStudio/BlbFile.cs
+++ b/AnimeStudio/BlbFile.cs
@@ -109,9 +109,16 @@ namespace AnimeStudio
                     size = reader.ReadInt32()
                 });
 
+                var pos = reader.Position;
+                reader.Position = flagInfoOffset + (i / 32) * 4;
+                var flag = reader.ReadUInt32();
+
+                m_DirectoryInfo[i].flags = ((flag >> (i % 32)) & 1) != 0 ? 4u : 0u;
+                reader.Position = pos;
+
                 var pathOffset = reader.Position + reader.ReadInt64();
 
-                var pos = reader.Position;
+                pos = reader.Position;
                 reader.Position = pathOffset;
                 m_DirectoryInfo[i].path = reader.ReadStringToNull();
                 reader.Position = pos;


### PR DESCRIPTION
This PR removes the incorrect flag parsing logic in `Blb3File.ReadBlocksInfoAndDirectory` to fix #71:

- Flags should be inherent properties of nodes, not determined by their index in the array
- The `flags` field is currently unused in the codebase, so this change doesn't affect existing functionality

This is my first time writing a PR, so please forgive me if there are any inappropriate parts.