### PR TITLE
Add AFK Journey support

### DIFF
--- a/AnimeStudio.GUI/Components/AssetItem.cs
+++ b/AnimeStudio.GUI/Components/AssetItem.cs
@@ -15,6 +15,9 @@ namespace AnimeStudio.GUI
         public string InfoText;
         public string UniqueID;
         public GameObjectTreeNode TreeNode;
+        public bool IsVirtual;
+        public string ExternalPath;
+        public string VirtualContent;
 
         public AssetItem(Object asset)
         {
@@ -26,6 +29,21 @@ namespace AnimeStudio.GUI
             m_PathID = asset.m_PathID;
             FullSize = asset.byteSize;
             Hash = asset.GetHash();
+        }
+
+        public AssetItem(string name, ClassIDType type, string externalPath, long fullSize, string container = "")
+        {
+            Asset = null;
+            SourceFile = null;
+            Text = name;
+            Type = type;
+            TypeString = type.ToString();
+            m_PathID = 0;
+            FullSize = fullSize;
+            Hash = string.Empty;
+            Container = container;
+            IsVirtual = true;
+            ExternalPath = externalPath;
         }
 
         public void SetSubItems()

--- a/AnimeStudio.GUI/Exporter.cs
+++ b/AnimeStudio.GUI/Exporter.cs
@@ -11,6 +11,67 @@ namespace AnimeStudio.GUI
 {
     internal static class Exporter
     {
+        public static bool ExportVirtualAsset(AssetItem item, string exportPath, ExportType exportType)
+        {
+            return exportType switch
+            {
+                ExportType.Convert => ExportVirtualConvertFile(item, exportPath),
+                ExportType.Raw => ExportVirtualRawFile(item, exportPath),
+                ExportType.Dump => ExportVirtualDumpFile(item, exportPath),
+                ExportType.JSON => ExportVirtualJsonFile(item, exportPath),
+                _ => false,
+            };
+        }
+
+        private static bool ExportVirtualConvertFile(AssetItem item, string exportPath)
+        {
+            switch (item.Type)
+            {
+                case ClassIDType.Texture2D:
+                    return AFKJourneyUtils.DecodeDxtFile(item.ExternalPath, Path.Combine(exportPath, item.Text)) != null;
+                case ClassIDType.TextAsset:
+                    if (!TryExportFile(exportPath, item, ".json", out var textPath))
+                        return false;
+                    var text = item.VirtualContent ?? AFKJourneyUtils.DecryptJsoneToText(File.ReadAllBytes(item.ExternalPath));
+                    File.WriteAllText(textPath, text);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool ExportVirtualRawFile(AssetItem item, string exportPath)
+        {
+            var extension = Path.GetExtension(item.ExternalPath);
+            if (!TryExportFile(exportPath, item, string.IsNullOrEmpty(extension) ? ".dat" : extension, out var rawPath))
+                return false;
+            File.Copy(item.ExternalPath, rawPath, overwrite: false);
+            return true;
+        }
+
+        private static bool ExportVirtualDumpFile(AssetItem item, string exportPath)
+        {
+            if (!TryExportFile(exportPath, item, ".txt", out var dumpPath))
+                return false;
+            var text = item.VirtualContent ?? item.InfoText ?? item.ExternalPath;
+            File.WriteAllText(dumpPath, text);
+            return true;
+        }
+
+        private static bool ExportVirtualJsonFile(AssetItem item, string exportPath)
+        {
+            if (item.Type != ClassIDType.TextAsset)
+            {
+                return ExportVirtualDumpFile(item, exportPath);
+            }
+
+            if (!TryExportFile(exportPath, item, ".json", out var jsonPath))
+                return false;
+            var text = item.VirtualContent ?? AFKJourneyUtils.DecryptJsoneToText(File.ReadAllBytes(item.ExternalPath));
+            File.WriteAllText(jsonPath, text);
+            return true;
+        }
+
         public static bool ExportTexture2D(AssetItem item, string exportPath)
         {
             var m_Texture2D = (Texture2D)item.Asset;

--- a/AnimeStudio.GUI/MainForm.cs
+++ b/AnimeStudio.GUI/MainForm.cs
@@ -465,8 +465,13 @@ namespace AnimeStudio.GUI
         {
             if (assetsManager.assetsFileList.Count == 0)
             {
-                if (Studio.Game?.Type == GameType.AFKJourney && BuildAFKJourneySpecialStructures(sourcePaths))
+                if (Studio.Game?.Type == GameType.AFKJourney && AddAFKJourneySpecialAssets(sourcePaths) > 0)
                 {
+                    visibleAssets = exportableAssets;
+                    assetListView.VirtualListSize = visibleAssets.Count;
+                    PopulateTypeFilters();
+                    Text = $"AnimeStudio v{System.Windows.Forms.Application.ProductVersion} - AFK Journey loose assets";
+                    StatusStripUpdate($"Loaded {visibleAssets.Count} AFK Journey loose files for preview.");
                     return;
                 }
 
@@ -497,6 +502,12 @@ namespace AnimeStudio.GUI
             }
 
             Text = $"AnimeStudio v{System.Windows.Forms.Application.ProductVersion} - {productName} - {assetsManager.assetsFileList[0].unityVersion} - {assetsManager.assetsFileList[0].m_TargetPlatform}";
+
+            if (Studio.Game?.Type == GameType.AFKJourney)
+            {
+                AddAFKJourneySpecialAssets(sourcePaths);
+                visibleAssets = exportableAssets;
+            }
 
             assetListView.VirtualListSize = visibleAssets.Count;
 
@@ -531,51 +542,52 @@ namespace AnimeStudio.GUI
             StatusStripUpdate(log);
         }
 
-        private bool BuildAFKJourneySpecialStructures(IEnumerable<string> sourcePaths)
+        private int AddAFKJourneySpecialAssets(IEnumerable<string> sourcePaths)
         {
-            var files = EnumerateAFKJourneySpecialFiles(sourcePaths).ToArray();
-            if (files.Length == 0)
-            {
-                return false;
-            }
-
-            foreach (var file in files)
+            var added = 0;
+            var existing = new HashSet<string>(
+                exportableAssets.Where(asset => asset.IsVirtual && !string.IsNullOrEmpty(asset.ExternalPath)).Select(asset => asset.ExternalPath),
+                StringComparer.OrdinalIgnoreCase);
+            foreach (var (file, container) in EnumerateAFKJourneySpecialFiles(sourcePaths))
             {
                 var type = Path.GetExtension(file).Equals(".jsone", StringComparison.OrdinalIgnoreCase)
                     ? ClassIDType.TextAsset
                     : ClassIDType.Texture2D;
-                var container = Path.GetDirectoryName(file) ?? string.Empty;
+                if (!existing.Add(file))
+                {
+                    continue;
+                }
+
                 var item = new AssetItem(Path.GetFileName(file), type, file, new FileInfo(file).Length, container);
                 item.InfoText = $"Path: {file}";
                 item.SetSubItems();
                 exportableAssets.Add(item);
+                added++;
             }
 
-            visibleAssets = exportableAssets;
-            assetListView.VirtualListSize = visibleAssets.Count;
-            PopulateTypeFilters();
-            Text = $"AnimeStudio v{System.Windows.Forms.Application.ProductVersion} - AFK Journey loose assets";
-            StatusStripUpdate($"Loaded {visibleAssets.Count} AFK Journey loose files for preview.");
-            return true;
+            return added;
         }
 
-        private static IEnumerable<string> EnumerateAFKJourneySpecialFiles(IEnumerable<string> sourcePaths)
+        private static IEnumerable<(string File, string Container)> EnumerateAFKJourneySpecialFiles(IEnumerable<string> sourcePaths)
         {
             foreach (var sourcePath in sourcePaths.Where(path => !string.IsNullOrEmpty(path)).Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 if (Directory.Exists(sourcePath))
                 {
+                    var root = Path.GetFullPath(sourcePath);
                     foreach (var file in Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories))
                     {
-                        if (AFKJourneyUtils.IsSupportedSpecialFile(file))
+                        if (AFKJourneyUtils.IsPreviewableSpecialFile(file))
                         {
-                            yield return file;
+                            var directory = Path.GetDirectoryName(Path.GetFullPath(file)) ?? root;
+                            var container = Path.GetRelativePath(root, directory);
+                            yield return (file, container == "." ? string.Empty : container);
                         }
                     }
                 }
-                else if (File.Exists(sourcePath) && AFKJourneyUtils.IsSupportedSpecialFile(sourcePath))
+                else if (File.Exists(sourcePath) && AFKJourneyUtils.IsPreviewableSpecialFile(sourcePath))
                 {
-                    yield return sourcePath;
+                    yield return (sourcePath, string.Empty);
                 }
             }
         }

--- a/AnimeStudio.GUI/MainForm.cs
+++ b/AnimeStudio.GUI/MainForm.cs
@@ -387,7 +387,7 @@ namespace AnimeStudio.GUI
             {
                 await Task.Run(() => assetsManager.LoadFiles(paths));
             }
-            BuildAssetStructures();
+            BuildAssetStructures(paths);
         }
 
         private async void loadFile_Click(object sender, EventArgs e)
@@ -405,7 +405,7 @@ namespace AnimeStudio.GUI
                     paths = File.ReadAllLines(paths[0]);
                 }
                 await Task.Run(() => assetsManager.LoadFiles(paths));
-                BuildAssetStructures();
+                BuildAssetStructures(paths);
             }
         }
 
@@ -424,7 +424,7 @@ namespace AnimeStudio.GUI
                 assetsManager.SpecifyUnityVersion = specifyUnityVersion.Text;
                 assetsManager.Game = Studio.Game;
                 await Task.Run(() => assetsManager.LoadFolder(openFolderDialog.Folder));
-                BuildAssetStructures();
+                BuildAssetStructures(openFolderDialog.Folder);
             }
         }
 
@@ -461,10 +461,15 @@ namespace AnimeStudio.GUI
             }
         }
 
-        private async void BuildAssetStructures()
+        private async void BuildAssetStructures(params string[] sourcePaths)
         {
             if (assetsManager.assetsFileList.Count == 0)
             {
+                if (Studio.Game?.Type == GameType.AFKJourney && BuildAFKJourneySpecialStructures(sourcePaths))
+                {
+                    return;
+                }
+
                 StatusStripUpdate("No Unity file can be loaded.");
                 return;
             }
@@ -515,6 +520,68 @@ namespace AnimeStudio.GUI
             typeMap.Clear();
             classesListView.EndUpdate();
 
+            PopulateTypeFilters();
+            var log = $"Finished loading {assetsManager.assetsFileList.Count} files with {visibleAssets.Count} exportable assets";
+            var m_ObjectsCount = assetsManager.assetsFileList.Sum(x => x.m_Objects.Count);
+            var objectsCount = assetsManager.assetsFileList.Sum(x => x.Objects.Count);
+            if (m_ObjectsCount != objectsCount)
+            {
+                log += $" and {m_ObjectsCount - objectsCount} assets failed to read";
+            }
+            StatusStripUpdate(log);
+        }
+
+        private bool BuildAFKJourneySpecialStructures(IEnumerable<string> sourcePaths)
+        {
+            var files = EnumerateAFKJourneySpecialFiles(sourcePaths).ToArray();
+            if (files.Length == 0)
+            {
+                return false;
+            }
+
+            foreach (var file in files)
+            {
+                var type = Path.GetExtension(file).Equals(".jsone", StringComparison.OrdinalIgnoreCase)
+                    ? ClassIDType.TextAsset
+                    : ClassIDType.Texture2D;
+                var container = Path.GetDirectoryName(file) ?? string.Empty;
+                var item = new AssetItem(Path.GetFileName(file), type, file, new FileInfo(file).Length, container);
+                item.InfoText = $"Path: {file}";
+                item.SetSubItems();
+                exportableAssets.Add(item);
+            }
+
+            visibleAssets = exportableAssets;
+            assetListView.VirtualListSize = visibleAssets.Count;
+            PopulateTypeFilters();
+            Text = $"AnimeStudio v{System.Windows.Forms.Application.ProductVersion} - AFK Journey loose assets";
+            StatusStripUpdate($"Loaded {visibleAssets.Count} AFK Journey loose files for preview.");
+            return true;
+        }
+
+        private static IEnumerable<string> EnumerateAFKJourneySpecialFiles(IEnumerable<string> sourcePaths)
+        {
+            foreach (var sourcePath in sourcePaths.Where(path => !string.IsNullOrEmpty(path)).Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                if (Directory.Exists(sourcePath))
+                {
+                    foreach (var file in Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories))
+                    {
+                        if (AFKJourneyUtils.IsSupportedSpecialFile(file))
+                        {
+                            yield return file;
+                        }
+                    }
+                }
+                else if (File.Exists(sourcePath) && AFKJourneyUtils.IsSupportedSpecialFile(sourcePath))
+                {
+                    yield return sourcePath;
+                }
+            }
+        }
+
+        private void PopulateTypeFilters()
+        {
             var types = exportableAssets.Select(x => x.Type).Distinct().OrderBy(x => x.ToString()).ToArray();
             foreach (var type in types)
             {
@@ -529,14 +596,6 @@ namespace AnimeStudio.GUI
                 filterTypeToolStripMenuItem.DropDownItems.Add(typeItem);
             }
             allToolStripMenuItem.Checked = true;
-            var log = $"Finished loading {assetsManager.assetsFileList.Count} files with {assetListView.Items.Count} exportable assets";
-            var m_ObjectsCount = assetsManager.assetsFileList.Sum(x => x.m_Objects.Count);
-            var objectsCount = assetsManager.assetsFileList.Sum(x => x.Objects.Count);
-            if (m_ObjectsCount != objectsCount)
-            {
-                log += $" and {m_ObjectsCount - objectsCount} assets failed to read";
-            }
-            StatusStripUpdate(log);
         }
 
         private void typeToolStripMenuItem_Click(object sender, EventArgs e)
@@ -972,7 +1031,9 @@ namespace AnimeStudio.GUI
             {
                 if (tabControl2.SelectedIndex == 1)
                 {
-                    dumpTextBox.Text = DumpAsset(lastSelectedItem.Asset);
+                    dumpTextBox.Text = lastSelectedItem.IsVirtual
+                        ? lastSelectedItem.VirtualContent ?? lastSelectedItem.InfoText ?? lastSelectedItem.ExternalPath
+                        : DumpAsset(lastSelectedItem.Asset);
                 }
                 if (enablePreview.Checked)
                 {
@@ -1017,6 +1078,12 @@ namespace AnimeStudio.GUI
                 return;
             try
             {
+                if (assetItem.IsVirtual)
+                {
+                    PreviewVirtualAsset(assetItem);
+                    return;
+                }
+
                 switch (assetItem.Asset)
                 {
                     case GameObject m_GameObject when Properties.Settings.Default.enableModelPreview:
@@ -1077,6 +1144,43 @@ namespace AnimeStudio.GUI
             catch (Exception e)
             {
                 Logger.Error($"Preview {assetItem.Type}:{assetItem.Text} error\r\n{e.Message}\r\n{e.StackTrace}");
+            }
+        }
+
+        private void PreviewVirtualAsset(AssetItem assetItem)
+        {
+            switch (assetItem.Type)
+            {
+                case ClassIDType.Texture2D:
+                    var decoded = AFKJourneyUtils.DecodeDxtToBitmapData(assetItem.ExternalPath);
+                    FlipPixelsVertically(decoded.Pixels, decoded.Width, decoded.Height);
+                    assetItem.InfoText = $"Width: {decoded.Width}\nHeight: {decoded.Height}\nFormat: {decoded.Format}\nPath: {assetItem.ExternalPath}";
+                    PreviewTexture(new DirectBitmap(decoded.Pixels, decoded.Width, decoded.Height));
+                    StatusStripUpdate("AFK Journey loose DXT texture preview");
+                    break;
+                case ClassIDType.TextAsset:
+                    assetItem.VirtualContent ??= AFKJourneyUtils.DecryptJsoneToText(File.ReadAllBytes(assetItem.ExternalPath));
+                    assetItem.InfoText = $"Path: {assetItem.ExternalPath}";
+                    PreviewText(assetItem.VirtualContent);
+                    StatusStripUpdate("AFK Journey loose JSOne preview");
+                    break;
+                default:
+                    StatusStripUpdate("Unsupported AFK Journey loose asset preview.");
+                    break;
+            }
+        }
+
+        private static void FlipPixelsVertically(byte[] pixels, int width, int height)
+        {
+            var stride = width * 4;
+            var row = new byte[stride];
+            for (var y = 0; y < height / 2; y++)
+            {
+                var top = y * stride;
+                var bottom = (height - y - 1) * stride;
+                System.Buffer.BlockCopy(pixels, top, row, 0, stride);
+                System.Buffer.BlockCopy(pixels, bottom, pixels, top, stride);
+                System.Buffer.BlockCopy(row, 0, pixels, bottom, stride);
             }
         }
 
@@ -1724,8 +1828,12 @@ namespace AnimeStudio.GUI
 
                 if (assetListView.SelectedIndices.Count == 1)
                 {
-                    goToSceneHierarchyToolStripMenuItem.Visible = true;
-                    showOriginalFileToolStripMenuItem.Visible = true;
+                    var selectedAsset = (AssetItem)assetListView.Items[assetListView.SelectedIndices[0]];
+                    if (!selectedAsset.IsVirtual)
+                    {
+                        goToSceneHierarchyToolStripMenuItem.Visible = true;
+                        showOriginalFileToolStripMenuItem.Visible = true;
+                    }
                 }
                 if (assetListView.SelectedIndices.Count >= 1)
                 {
@@ -1769,6 +1877,11 @@ namespace AnimeStudio.GUI
         private void showOriginalFileToolStripMenuItem_Click(object sender, EventArgs e)
         {
             var selectasset = (AssetItem)assetListView.Items[assetListView.SelectedIndices[0]];
+            if (selectasset.IsVirtual || selectasset.SourceFile == null)
+            {
+                return;
+            }
+
             var args = $"/select, \"{selectasset.SourceFile.originalPath ?? selectasset.SourceFile.fullName}\"";
             var pfi = new ProcessStartInfo("explorer.exe", args);
             Process.Start(pfi);

--- a/AnimeStudio.GUI/Studio.cs
+++ b/AnimeStudio.GUI/Studio.cs
@@ -693,7 +693,11 @@ namespace AnimeStudio.GUI
                             }
                             break;
                         case AssetGroupOption.BySource: //source file
-                            if (string.IsNullOrEmpty(asset.SourceFile.originalPath))
+                            if (asset.IsVirtual)
+                            {
+                                exportPath = Path.Combine(savePath, Path.GetFileName(asset.ExternalPath) + "_export");
+                            }
+                            else if (string.IsNullOrEmpty(asset.SourceFile.originalPath))
                             {
                                 exportPath = Path.Combine(savePath, asset.SourceFile.fileName + "_export");
                             }

--- a/AnimeStudio.GUI/Studio.cs
+++ b/AnimeStudio.GUI/Studio.cs
@@ -71,6 +71,11 @@ namespace AnimeStudio.GUI
 
         public static int ExtractFile(string fileName, string savePath)
         {
+            if (Game?.Type == GameType.AFKJourney && AFKJourneyUtils.IsSupportedSpecialFile(fileName))
+            {
+                return AFKJourneyUtils.TryExtractSpecialFile(fileName, savePath);
+            }
+
             int extractedCount = 0;
             var reader = new FileReader(fileName);
             reader = reader.PreProcessing(Game);
@@ -705,6 +710,16 @@ namespace AnimeStudio.GUI
                     StatusStripUpdate($"[{exportedCount}/{toExportCount}] Exporting {asset.TypeString}: {asset.Text}");
                     try
                     {
+                        if (asset.IsVirtual)
+                        {
+                            if (ExportVirtualAsset(asset, exportPath, exportType))
+                            {
+                                exportedCount++;
+                            }
+                            Progress.Report(++i, toExportCount);
+                            continue;
+                        }
+
                         switch (exportType)
                         {
                             case ExportType.Raw:

--- a/AnimeStudio/AFKJourneyUtils.cs
+++ b/AnimeStudio/AFKJourneyUtils.cs
@@ -1,0 +1,388 @@
+using Org.BouncyCastle.Crypto.Engines;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Enumeration;
+using System.Linq;
+using System.Text;
+using Texture2DDecoder;
+using ZstdSharp;
+
+namespace AnimeStudio
+{
+    public readonly record struct AFKJourneyPkgEntry(
+        long Offset,
+        string Filename,
+        int CompressedSize,
+        int UncompressedSize,
+        uint Crc32,
+        ushort Method,
+        long DataOffset);
+
+    public static class AFKJourneyUtils
+    {
+        private static readonly byte[] JsoneMagic = { 0xFF, 0xFF, 0xFF, 0xFF };
+        private static readonly byte[] ZipLocalHeader = { 0x50, 0x4B, 0x03, 0x04 };
+        private static readonly byte[] BlowfishKey = Encoding.ASCII.GetBytes("b8c0aeff2944d1614d6bc63dc6b0a537");
+        private const int ScanChunkSize = 64 * 1024 * 1024;
+        private const int ScanOverlap = 256;
+        private const byte FmtEtc1Rgb = 0x0A;
+        private const byte FmtEtc1Rgba = 0x0B;
+        private const byte FmtBc7 = 0x10;
+        private const ushort PkgMethodStored = 0;
+        private const ushort PkgMethodZstd = 20;
+
+        public static bool HasDxtHeader(ReadOnlySpan<byte> data) => data.Length >= 3 && data[0] == (byte)'D' && data[1] == (byte)'X' && data[2] == (byte)'T';
+        public static bool HasJsoneHeader(ReadOnlySpan<byte> data) => data.Length >= 4 && data[..4].SequenceEqual(JsoneMagic);
+
+        public static bool IsSupportedSpecialFile(string path)
+        {
+            using var stream = File.OpenRead(path);
+            Span<byte> header = stackalloc byte[12];
+            var read = stream.Read(header);
+            var data = header[..read];
+            return HasDxtHeader(data) || HasJsoneHeader(data) || IsPkgPath(path);
+        }
+
+        public static int TryExtractSpecialFile(string path, string outputDirectory)
+        {
+            using var stream = File.OpenRead(path);
+            Span<byte> header = stackalloc byte[12];
+            var read = stream.Read(header);
+            var data = header[..read];
+
+            if (HasDxtHeader(data))
+            {
+                DecodeDxtFile(path, Path.Combine(outputDirectory, Path.GetFileName(path)));
+                return 1;
+            }
+
+            if (HasJsoneHeader(data) && Path.GetExtension(path).Equals(".jsone", StringComparison.OrdinalIgnoreCase))
+            {
+                DecryptJsoneFile(path, outputDirectory);
+                return 1;
+            }
+
+            if (IsPkgPath(path))
+            {
+                return ExtractPkgEntries(path, Path.Combine(outputDirectory, Path.GetFileName(path) + "_unpacked"));
+            }
+
+            return 0;
+        }
+
+        public static string DecryptJsoneToText(byte[] data)
+        {
+            if (!HasJsoneHeader(data))
+            {
+                throw new InvalidDataException("JSOne file does not start with the expected magic header.");
+            }
+
+            if (data.Length < 8)
+            {
+                throw new InvalidDataException("JSOne file is truncated.");
+            }
+
+            var totalSize = data.Length;
+            var declaredSize = BinaryPrimitives.ReadUInt32LittleEndian(data.AsSpan(4, 4));
+            var payload = data.AsSpan(8).ToArray();
+            var engine = new BlowfishEngine();
+            engine.Init(false, new Org.BouncyCastle.Crypto.Parameters.KeyParameter(BlowfishKey));
+
+            var blockCount = ((totalSize - 4 - 5) >> 3) + 1;
+            var tempIn = new byte[8];
+            var tempOut = new byte[8];
+            for (var i = 0; i < blockCount; i++)
+            {
+                var offset = i * 8;
+                if (offset + 8 > payload.Length)
+                {
+                    break;
+                }
+
+                var block = payload.AsSpan(offset, 8);
+                SwapHalves(block, tempIn);
+                engine.ProcessBlock(tempIn, 0, tempOut, 0);
+                SwapHalves(tempOut, block);
+            }
+
+            if (payload.Length < 4)
+            {
+                throw new InvalidDataException("JSOne decrypted payload is too small.");
+            }
+
+            var prefixLength = BinaryPrimitives.ReadUInt32LittleEndian(payload.AsSpan(0, 4));
+            var remainingSize = checked((int)declaredSize - (int)prefixLength - 4);
+            var compressedOffset = checked((int)prefixLength + 4);
+            if (remainingSize <= 4 || compressedOffset < 0 || compressedOffset + remainingSize > payload.Length)
+            {
+                throw new InvalidDataException("JSOne decrypted payload has invalid compressed data bounds.");
+            }
+
+            var compressed = payload.AsSpan(compressedOffset, remainingSize);
+            var decompressedSize = BinaryPrimitives.ReadInt32LittleEndian(compressed[..4]);
+            if (decompressedSize <= 0)
+            {
+                throw new InvalidDataException("JSOne LZ4 payload has invalid decompressed size.");
+            }
+
+            var decompressed = new byte[decompressedSize];
+            var written = LZ4.Instance.Decompress(compressed[4..], decompressed);
+            if (written != decompressedSize)
+            {
+                throw new InvalidDataException($"JSOne LZ4 decompression wrote {written} bytes, expected {decompressedSize}.");
+            }
+
+            return Encoding.UTF8.GetString(decompressed);
+        }
+
+        public static string DecryptJsoneFile(string path, string outputDirectory)
+        {
+            var text = DecryptJsoneToText(File.ReadAllBytes(path));
+            Directory.CreateDirectory(outputDirectory);
+            var outputPath = Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(path) + ".json");
+            File.WriteAllText(outputPath, text, Encoding.UTF8);
+            return outputPath;
+        }
+
+        public static string DecodeDxtFile(string path, string outputPath)
+        {
+            var decoded = DecodeDxtToBitmapData(path);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            var finalOutputPath = Path.ChangeExtension(outputPath, ".png");
+            using var image = Image.LoadPixelData<Bgra32>(decoded.Pixels, decoded.Width, decoded.Height);
+            image.Mutate(static ctx => ctx.Flip(FlipMode.Vertical));
+            image.SaveAsPng(finalOutputPath, new PngEncoder());
+            return finalOutputPath;
+        }
+
+        public static (byte[] Pixels, int Width, int Height, string Format) DecodeDxtToBitmapData(string path)
+        {
+            var data = File.ReadAllBytes(path);
+            if (!HasDxtHeader(data))
+            {
+                throw new InvalidDataException("DXT file does not start with the expected magic header.");
+            }
+
+            if (data.Length < 12)
+            {
+                throw new InvalidDataException("DXT file is truncated.");
+            }
+
+            var width = data[3] | (data[4] << 8);
+            var height = data[5] | (data[6] << 8);
+            var format = data[7];
+            var decompressedSize = BinaryPrimitives.ReadInt32LittleEndian(data.AsSpan(8, 4));
+            if (width <= 0 || height <= 0 || decompressedSize <= 0)
+            {
+                throw new InvalidDataException("DXT file has invalid dimensions or payload size.");
+            }
+
+            var raw = new byte[decompressedSize];
+            var written = LZ4.Instance.Decompress(data.AsSpan(12), raw);
+            if (written != decompressedSize)
+            {
+                throw new InvalidDataException($"DXT LZ4 decompression wrote {written} bytes, expected {decompressedSize}.");
+            }
+
+            var pixelData = new byte[width * height * 4];
+            var formatName = format switch
+            {
+                FmtBc7 => "BC7",
+                FmtEtc1Rgb => "ETC1_RGB",
+                FmtEtc1Rgba => "ETC1_RGBA",
+                _ => $"0x{format:X2}",
+            };
+            bool success = format switch
+            {
+                FmtBc7 => TextureDecoder.DecodeBC7(raw, width, height, pixelData),
+                FmtEtc1Rgb => TextureDecoder.DecodeETC1(raw, width, height, pixelData),
+                FmtEtc1Rgba => TextureDecoder.DecodeETC1(raw, width, height, pixelData),
+                _ => throw new InvalidDataException($"Unsupported AFK Journey DXT texture format 0x{format:X2}.")
+            };
+
+            if (!success)
+            {
+                throw new InvalidDataException("DXT texture decoder failed.");
+            }
+
+            return (pixelData, width, height, formatName);
+        }
+
+        public static List<AFKJourneyPkgEntry> ScanPkgEntries(string path, bool progress = true)
+        {
+            var entries = new List<AFKJourneyPkgEntry>();
+            var seenOffsets = new HashSet<long>();
+            var fileInfo = new FileInfo(path);
+            long offset = 0;
+
+            using var stream = File.OpenRead(path);
+            while (offset < fileInfo.Length)
+            {
+                stream.Position = offset;
+                var chunkSize = (int)Math.Min(ScanChunkSize, fileInfo.Length - offset);
+                if (chunkSize <= 0)
+                {
+                    break;
+                }
+
+                var chunk = new byte[chunkSize];
+                var read = stream.Read(chunk, 0, chunkSize);
+                if (read <= 0)
+                {
+                    break;
+                }
+
+                var span = chunk.AsSpan(0, read);
+                var searchOffset = 0;
+                while (searchOffset < span.Length)
+                {
+                    var index = span[searchOffset..].IndexOf(ZipLocalHeader);
+                    if (index < 0)
+                    {
+                        break;
+                    }
+
+                    index += searchOffset;
+                    var absoluteOffset = offset + index;
+                    searchOffset = index + 4;
+                    if (seenOffsets.Contains(absoluteOffset) || index + 30 > span.Length)
+                    {
+                        continue;
+                    }
+
+                    var version = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(index + 4, 2));
+                    var method = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(index + 8, 2));
+                    var crc32 = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(index + 14, 4));
+                    var compressedSize = BinaryPrimitives.ReadInt32LittleEndian(span.Slice(index + 18, 4));
+                    var uncompressedSize = BinaryPrimitives.ReadInt32LittleEndian(span.Slice(index + 22, 4));
+                    var nameLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(index + 26, 2));
+                    var extraLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(index + 28, 2));
+
+                    var valid =
+                        version >= 10 && version <= 63 &&
+                        nameLength > 0 && nameLength < 1024 &&
+                        extraLength < 4096 &&
+                        compressedSize >= 0 &&
+                        index + 30 + nameLength <= span.Length;
+                    if (!valid)
+                    {
+                        continue;
+                    }
+
+                    var nameBytes = span.Slice(index + 30, nameLength).ToArray();
+                    var filename = Encoding.UTF8.GetString(nameBytes);
+                    if (filename.EndsWith('/'))
+                    {
+                        continue;
+                    }
+
+                    var dataOffset = absoluteOffset + 30 + nameLength + extraLength;
+                    entries.Add(new AFKJourneyPkgEntry(absoluteOffset, filename, compressedSize, uncompressedSize, crc32, method, dataOffset));
+                    seenOffsets.Add(absoluteOffset);
+                }
+
+                offset += Math.Max(1, ScanChunkSize - ScanOverlap);
+                if (progress && offset < fileInfo.Length)
+                {
+                    Progress.Report((int)Math.Min(offset, fileInfo.Length), (int)Math.Min(fileInfo.Length, int.MaxValue));
+                }
+            }
+
+            return entries;
+        }
+
+        public static int ExtractPkgEntries(string path, string outputDirectory, string filterPattern = null)
+        {
+            var entries = ScanPkgEntries(path, progress: false);
+            if (!string.IsNullOrEmpty(filterPattern))
+            {
+                entries = entries.Where(entry => FileSystemName.MatchesSimpleExpression(filterPattern, entry.Filename)).ToList();
+            }
+
+            Directory.CreateDirectory(outputDirectory);
+            var extracted = 0;
+            using var stream = File.OpenRead(path);
+            using var decompressor = new Decompressor();
+            foreach (var entry in entries)
+            {
+                stream.Position = entry.DataOffset;
+                var outputPath = Path.Combine(outputDirectory, entry.Filename.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+                switch (entry.Method)
+                {
+                    case PkgMethodStored:
+                    {
+                        using var output = File.Create(outputPath);
+                        CopyBytes(stream, output, entry.CompressedSize);
+                        extracted++;
+                        break;
+                    }
+                    case PkgMethodZstd:
+                    {
+                        var compressed = new byte[entry.CompressedSize];
+                        FillBuffer(stream, compressed);
+                        var uncompressed = new byte[entry.UncompressedSize];
+                        var written = decompressor.Unwrap(compressed, 0, compressed.Length, uncompressed, 0, uncompressed.Length);
+                        if (written != entry.UncompressedSize)
+                        {
+                            throw new InvalidDataException($"Zstd decompression wrote {written} bytes, expected {entry.UncompressedSize}.");
+                        }
+                        File.WriteAllBytes(outputPath, uncompressed);
+                        extracted++;
+                        break;
+                    }
+                    default:
+                        throw new InvalidDataException($"Unsupported AFK Journey pkg compression method {entry.Method} for {entry.Filename}.");
+                }
+            }
+
+            return extracted;
+        }
+
+        private static bool IsPkgPath(string path) => Path.GetExtension(path).Equals(".pkg", StringComparison.OrdinalIgnoreCase);
+
+        private static void SwapHalves(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            source[..4].CopyTo(destination[..4]);
+            source[4..8].CopyTo(destination[4..8]);
+            destination[..4].Reverse();
+            destination[4..8].Reverse();
+        }
+
+        private static void CopyBytes(Stream input, Stream output, int count)
+        {
+            var buffer = new byte[Math.Min(count, 4 * 1024 * 1024)];
+            var remaining = count;
+            while (remaining > 0)
+            {
+                var read = input.Read(buffer, 0, Math.Min(buffer.Length, remaining));
+                if (read <= 0)
+                {
+                    throw new EndOfStreamException("Unexpected end of stream while copying pkg entry data.");
+                }
+                output.Write(buffer, 0, read);
+                remaining -= read;
+            }
+        }
+
+        private static void FillBuffer(Stream input, byte[] buffer)
+        {
+            var totalRead = 0;
+            while (totalRead < buffer.Length)
+            {
+                var read = input.Read(buffer, totalRead, buffer.Length - totalRead);
+                if (read <= 0)
+                {
+                    throw new EndOfStreamException("Unexpected end of stream while reading pkg entry data.");
+                }
+                totalRead += read;
+            }
+        }
+    }
+}

--- a/AnimeStudio/AFKJourneyUtils.cs
+++ b/AnimeStudio/AFKJourneyUtils.cs
@@ -42,11 +42,16 @@ namespace AnimeStudio
 
         public static bool IsSupportedSpecialFile(string path)
         {
+            return IsPreviewableSpecialFile(path) || IsPkgPath(path);
+        }
+
+        public static bool IsPreviewableSpecialFile(string path)
+        {
             using var stream = File.OpenRead(path);
             Span<byte> header = stackalloc byte[12];
             var read = stream.Read(header);
             var data = header[..read];
-            return HasDxtHeader(data) || HasJsoneHeader(data) || IsPkgPath(path);
+            return HasDxtHeader(data) || (HasJsoneHeader(data) && Path.GetExtension(path).Equals(".jsone", StringComparison.OrdinalIgnoreCase));
         }
 
         public static int TryExtractSpecialFile(string path, string outputDirectory)
@@ -305,14 +310,15 @@ namespace AnimeStudio
                 entries = entries.Where(entry => FileSystemName.MatchesSimpleExpression(filterPattern, entry.Filename)).ToList();
             }
 
-            Directory.CreateDirectory(outputDirectory);
+            var outputRoot = Path.GetFullPath(outputDirectory);
+            Directory.CreateDirectory(outputRoot);
             var extracted = 0;
             using var stream = File.OpenRead(path);
             using var decompressor = new Decompressor();
             foreach (var entry in entries)
             {
                 stream.Position = entry.DataOffset;
-                var outputPath = Path.Combine(outputDirectory, entry.Filename.Replace('/', Path.DirectorySeparatorChar));
+                var outputPath = GetSafePkgOutputPath(outputRoot, entry.Filename);
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
                 switch (entry.Method)
                 {
@@ -346,6 +352,32 @@ namespace AnimeStudio
         }
 
         private static bool IsPkgPath(string path) => Path.GetExtension(path).Equals(".pkg", StringComparison.OrdinalIgnoreCase);
+
+        private static string GetSafePkgOutputPath(string outputDirectory, string filename)
+        {
+            var normalized = filename.Replace('\\', '/');
+            if (Path.IsPathRooted(normalized))
+            {
+                throw new InvalidDataException($"Pkg entry has an absolute path: {filename}");
+            }
+
+            var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0 || parts.Any(part => part == "." || part == ".."))
+            {
+                throw new InvalidDataException($"Pkg entry has an invalid path: {filename}");
+            }
+
+            var outputPath = Path.GetFullPath(Path.Combine(new[] { outputDirectory }.Concat(parts).ToArray()));
+            var outputRoot = outputDirectory.EndsWith(Path.DirectorySeparatorChar)
+                ? outputDirectory
+                : outputDirectory + Path.DirectorySeparatorChar;
+            if (!outputPath.StartsWith(outputRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidDataException($"Pkg entry escapes the output directory: {filename}");
+            }
+
+            return outputPath;
+        }
 
         private static void SwapHalves(ReadOnlySpan<byte> source, Span<byte> destination)
         {

--- a/AnimeStudio/AFKJourneyUtils.cs
+++ b/AnimeStudio/AFKJourneyUtils.cs
@@ -24,12 +24,25 @@ namespace AnimeStudio
         ushort Method,
         long DataOffset);
 
+    public readonly record struct AFKJourneyUnityFsChunk(
+        int Index,
+        long Offset,
+        long Size,
+        uint Version,
+        string UnityVersion,
+        string UnityRevision,
+        uint CompressedBlocksInfoSize,
+        uint UncompressedBlocksInfoSize,
+        uint Flags);
+
     public static class AFKJourneyUtils
     {
         private static readonly byte[] JsoneMagic = { 0xFF, 0xFF, 0xFF, 0xFF };
         private static readonly byte[] ZipLocalHeader = { 0x50, 0x4B, 0x03, 0x04 };
+        private static readonly byte[] UnityFsMagic = Encoding.ASCII.GetBytes("UnityFS\0");
         private static readonly byte[] BlowfishKey = Encoding.ASCII.GetBytes("b8c0aeff2944d1614d6bc63dc6b0a537");
         private const int ScanChunkSize = 64 * 1024 * 1024;
+        private const int UnityFsScanChunkSize = 8 * 1024 * 1024;
         private const int ScanOverlap = 256;
         private const byte FmtEtc1Rgb = 0x0A;
         private const byte FmtEtc1Rgba = 0x0B;
@@ -39,6 +52,7 @@ namespace AnimeStudio
 
         public static bool HasDxtHeader(ReadOnlySpan<byte> data) => data.Length >= 3 && data[0] == (byte)'D' && data[1] == (byte)'X' && data[2] == (byte)'T';
         public static bool HasJsoneHeader(ReadOnlySpan<byte> data) => data.Length >= 4 && data[..4].SequenceEqual(JsoneMagic);
+        public static bool IsLpakPath(string path) => Path.GetExtension(path).Equals(".lpak", StringComparison.OrdinalIgnoreCase);
 
         public static bool IsSupportedSpecialFile(string path)
         {
@@ -79,6 +93,178 @@ namespace AnimeStudio
             }
 
             return 0;
+        }
+
+        public static List<AFKJourneyUnityFsChunk> ScanLpakUnityFsChunks(string path)
+        {
+            var chunks = new List<AFKJourneyUnityFsChunk>();
+            if (!IsLpakPath(path) || !File.Exists(path))
+            {
+                return chunks;
+            }
+
+            var fileInfo = new FileInfo(path);
+            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            var offsets = FindUnityFsOffsets(stream);
+            var nextAllowedOffset = 0L;
+
+            foreach (var offset in offsets)
+            {
+                if (offset < nextAllowedOffset)
+                {
+                    continue;
+                }
+
+                if (!TryReadUnityFsChunkHeader(stream, offset, fileInfo.Length, chunks.Count, out var chunk))
+                {
+                    continue;
+                }
+
+                chunks.Add(chunk);
+                nextAllowedOffset = chunk.Offset + chunk.Size;
+            }
+
+            return chunks;
+        }
+
+        public static string GetLpakChunkVirtualPath(string path, AFKJourneyUnityFsChunk chunk)
+        {
+            var directory = Path.GetDirectoryName(Path.GetFullPath(path)) ?? string.Empty;
+            var stem = Path.GetFileNameWithoutExtension(path);
+            var chunkName = $"{stem}__{chunk.Index:D5}__0x{chunk.Offset:X16}.bundle";
+            return Path.Combine(directory, Path.GetFileName(path) + "_chunks", chunkName);
+        }
+
+        private static List<long> FindUnityFsOffsets(Stream stream)
+        {
+            var offsets = new List<long>();
+            var previous = Array.Empty<byte>();
+            var buffer = new byte[UnityFsScanChunkSize];
+            long absolute = 0;
+
+            stream.Position = 0;
+            while (true)
+            {
+                var read = stream.Read(buffer, 0, buffer.Length);
+                if (read <= 0)
+                {
+                    break;
+                }
+
+                var data = new byte[previous.Length + read];
+                if (previous.Length > 0)
+                {
+                    Buffer.BlockCopy(previous, 0, data, 0, previous.Length);
+                }
+                Buffer.BlockCopy(buffer, 0, data, previous.Length, read);
+
+                var searchOffset = 0;
+                while (searchOffset < data.Length)
+                {
+                    var found = data.AsSpan(searchOffset).IndexOf(UnityFsMagic);
+                    if (found < 0)
+                    {
+                        break;
+                    }
+
+                    found += searchOffset;
+                    offsets.Add(absolute - previous.Length + found);
+                    searchOffset = found + 1;
+                }
+
+                absolute += read;
+                var keep = Math.Min(UnityFsMagic.Length - 1, data.Length);
+                previous = new byte[keep];
+                Buffer.BlockCopy(data, data.Length - keep, previous, 0, keep);
+            }
+
+            return offsets;
+        }
+
+        private static bool TryReadUnityFsChunkHeader(Stream stream, long offset, long fileSize, int index, out AFKJourneyUnityFsChunk chunk)
+        {
+            chunk = default;
+
+            try
+            {
+                stream.Position = offset;
+                Span<byte> magic = stackalloc byte[8];
+                if (stream.Read(magic) != magic.Length || !magic.SequenceEqual(UnityFsMagic))
+                {
+                    return false;
+                }
+
+                using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+                var version = ReadUInt32BigEndian(reader);
+                var unityVersion = ReadNullTerminatedString(reader, 256);
+                var unityRevision = ReadNullTerminatedString(reader, 256);
+                var size = ReadInt64BigEndian(reader);
+                var compressedBlocksInfoSize = ReadUInt32BigEndian(reader);
+                var uncompressedBlocksInfoSize = ReadUInt32BigEndian(reader);
+                var flags = ReadUInt32BigEndian(reader);
+
+                if (size <= 0 || offset + size > fileSize)
+                {
+                    return false;
+                }
+
+                if (version == 0 || string.IsNullOrEmpty(unityVersion) || string.IsNullOrEmpty(unityRevision))
+                {
+                    return false;
+                }
+
+                chunk = new AFKJourneyUnityFsChunk(
+                    index,
+                    offset,
+                    size,
+                    version,
+                    unityVersion,
+                    unityRevision,
+                    compressedBlocksInfoSize,
+                    uncompressedBlocksInfoSize,
+                    flags);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string ReadNullTerminatedString(BinaryReader reader, int maxBytes)
+        {
+            var bytes = new List<byte>();
+            for (var i = 0; i < maxBytes; i++)
+            {
+                var value = reader.ReadByte();
+                if (value == 0)
+                {
+                    return Encoding.UTF8.GetString(bytes.ToArray());
+                }
+                bytes.Add(value);
+            }
+
+            throw new InvalidDataException("UnityFS header string is not null terminated.");
+        }
+
+        private static uint ReadUInt32BigEndian(BinaryReader reader)
+        {
+            Span<byte> data = stackalloc byte[4];
+            if (reader.Read(data) != data.Length)
+            {
+                throw new EndOfStreamException();
+            }
+            return BinaryPrimitives.ReadUInt32BigEndian(data);
+        }
+
+        private static long ReadInt64BigEndian(BinaryReader reader)
+        {
+            Span<byte> data = stackalloc byte[8];
+            if (reader.Read(data) != data.Length)
+            {
+                throw new EndOfStreamException();
+            }
+            return BinaryPrimitives.ReadInt64BigEndian(data);
         }
 
         public static string DecryptJsoneToText(byte[] data)

--- a/AnimeStudio/AnimeStudio.csproj
+++ b/AnimeStudio/AnimeStudio.csproj
@@ -12,6 +12,7 @@
 		<PackageReference Include="Kyaru.Texture2DDecoder.Windows" Version="0.1.0" />
 		<PackageReference Include="MessagePack" Version="3.1.4" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
 		<PackageReference Include="ZstdSharp.Port" Version="0.8.6" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
 	</ItemGroup>

--- a/AnimeStudio/AssetsManager.cs
+++ b/AnimeStudio/AssetsManager.cs
@@ -70,6 +70,7 @@ namespace AnimeStudio
                 Progress.Silent = true;
             }
 
+            files = OrderFilesForLoading(files);
             var path = Path.GetDirectoryName(Path.GetFullPath(files[0]));
             MergeSplitAssets(path);
             var toReadFile = ProcessingSplitFiles(files.ToList());
@@ -93,7 +94,7 @@ namespace AnimeStudio
             }
 
             MergeSplitAssets(path, true);
-            var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories).ToList();
+            var files = OrderFilesForLoading(Directory.GetFiles(path, "*.*", SearchOption.AllDirectories)).ToList();
             var toReadFile = ProcessingSplitFiles(files);
             Load(toReadFile);
 
@@ -137,6 +138,25 @@ namespace AnimeStudio
                 ReadAssets();
                 ProcessAssets();
             }
+        }
+
+        private static string[] OrderFilesForLoading(IEnumerable<string> files)
+        {
+            return files
+                .OrderBy(file => GetLoadPriority(Path.GetFileName(file)))
+                .ThenBy(file => new FileInfo(file).Length)
+                .ThenBy(file => file, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        private static int GetLoadPriority(string fileName)
+        {
+            return fileName.ToLowerInvariant() switch
+            {
+                "globalgamemanagers" => 0,
+                "data.unity3d" => 1,
+                _ => 2,
+            };
         }
 
         private void LoadFile(string fullName)
@@ -272,6 +292,7 @@ namespace AnimeStudio
 
         private void LoadAssetsFromMemory(FileReader reader, string originalPath, string unityVersion = null, long originalOffset = 0)
         {
+            unityVersion = ResolveUnityVersionHint(originalPath, unityVersion);
             Logger.Verbose($"Loading asset file {reader.FileName} with version {unityVersion} from {originalPath} at offset 0x{originalOffset:X8}");
             if (!assetsFileListHash.Contains(reader.FileName))
             {
@@ -280,7 +301,7 @@ namespace AnimeStudio
                     var assetsFile = new SerializedFile(reader, this);
                     assetsFile.originalPath = originalPath;
                     assetsFile.offset = originalOffset;
-                    if (!string.IsNullOrEmpty(unityVersion) && assetsFile.header.m_Version < SerializedFileFormatVersion.Unknown_7)
+                    if (!string.IsNullOrEmpty(unityVersion) && (assetsFile.header.m_Version < SerializedFileFormatVersion.Unknown_7 || assetsFile.IsVersionStripped || assetsFile.unityVersion == "0.0.0"))
                     {
                         assetsFile.SetVersion(unityVersion);
                     }
@@ -297,6 +318,51 @@ namespace AnimeStudio
             }
             else
                 Logger.Info($"Skipping {originalPath} ({reader.FileName})");
+        }
+
+        private string ResolveUnityVersionHint(string originalPath, string unityVersion)
+        {
+            if (!string.IsNullOrEmpty(unityVersion) && unityVersion != "0.0.0")
+            {
+                return unityVersion;
+            }
+
+            if (!string.IsNullOrEmpty(SpecifyUnityVersion))
+            {
+                return SpecifyUnityVersion;
+            }
+
+            if (Game?.Type != GameType.AFKJourney || string.IsNullOrEmpty(originalPath))
+            {
+                return unityVersion;
+            }
+
+            try
+            {
+                var directory = Path.GetDirectoryName(Path.GetFullPath(originalPath));
+                while (!string.IsNullOrEmpty(directory))
+                {
+                    var globalGameManagersPath = Path.Combine(directory, "globalgamemanagers");
+                    if (File.Exists(globalGameManagersPath))
+                    {
+                        using var versionReader = new FileReader(globalGameManagersPath);
+                        var versionFile = new SerializedFile(versionReader, this);
+                        if (!string.IsNullOrEmpty(versionFile.unityVersion) && versionFile.unityVersion != "0.0.0")
+                        {
+                            Logger.Verbose($"Resolved AFK Journey Unity version {versionFile.unityVersion} from {globalGameManagersPath}");
+                            return versionFile.unityVersion;
+                        }
+                    }
+
+                    directory = Path.GetDirectoryName(directory);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Verbose($"Failed to resolve AFK Journey Unity version from install root: {ex.Message}");
+            }
+
+            return unityVersion;
         }
 
         private void LoadWebFile(FileReader reader)
@@ -583,6 +649,11 @@ namespace AnimeStudio
 
         public void CheckStrippedVersion(SerializedFile assetsFile)
         {
+            if (!assetsFile.IsVersionStripped && string.IsNullOrEmpty(SpecifyUnityVersion) && !string.IsNullOrEmpty(assetsFile.unityVersion) && assetsFile.unityVersion != "0.0.0")
+            {
+                SpecifyUnityVersion = assetsFile.unityVersion;
+            }
+
             if (assetsFile.IsVersionStripped && string.IsNullOrEmpty(SpecifyUnityVersion))
             {
                 throw new Exception("The Unity version has been stripped, please set the version in the options");

--- a/AnimeStudio/AssetsManager.cs
+++ b/AnimeStudio/AssetsManager.cs
@@ -70,7 +70,10 @@ namespace AnimeStudio
                 Progress.Silent = true;
             }
 
-            files = OrderFilesForLoading(files);
+            if (Game?.Type == GameType.AFKJourney)
+            {
+                files = OrderFilesForLoading(files);
+            }
             var path = Path.GetDirectoryName(Path.GetFullPath(files[0]));
             MergeSplitAssets(path);
             var toReadFile = ProcessingSplitFiles(files.ToList());
@@ -94,7 +97,11 @@ namespace AnimeStudio
             }
 
             MergeSplitAssets(path, true);
-            var files = OrderFilesForLoading(Directory.GetFiles(path, "*.*", SearchOption.AllDirectories)).ToList();
+            var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories).ToList();
+            if (Game?.Type == GameType.AFKJourney)
+            {
+                files = OrderFilesForLoading(files).ToList();
+            }
             var toReadFile = ProcessingSplitFiles(files);
             Load(toReadFile);
 
@@ -649,7 +656,7 @@ namespace AnimeStudio
 
         public void CheckStrippedVersion(SerializedFile assetsFile)
         {
-            if (!assetsFile.IsVersionStripped && string.IsNullOrEmpty(SpecifyUnityVersion) && !string.IsNullOrEmpty(assetsFile.unityVersion) && assetsFile.unityVersion != "0.0.0")
+            if (Game?.Type == GameType.AFKJourney && !assetsFile.IsVersionStripped && string.IsNullOrEmpty(SpecifyUnityVersion) && !string.IsNullOrEmpty(assetsFile.unityVersion) && assetsFile.unityVersion != "0.0.0")
             {
                 SpecifyUnityVersion = assetsFile.unityVersion;
             }

--- a/AnimeStudio/AssetsManager.cs
+++ b/AnimeStudio/AssetsManager.cs
@@ -168,9 +168,50 @@ namespace AnimeStudio
 
         private void LoadFile(string fullName)
         {
+            if (Game?.Type == GameType.AFKJourney && AFKJourneyUtils.IsLpakPath(fullName))
+            {
+                if (LoadAfkJourneyLpakFile(fullName))
+                {
+                    return;
+                }
+            }
+
             var reader = new FileReader(fullName);
             reader = reader.PreProcessing(Game);
             LoadFile(reader);
+        }
+
+        private bool LoadAfkJourneyLpakFile(string fullName)
+        {
+            var chunks = AFKJourneyUtils.ScanLpakUnityFsChunks(fullName);
+            if (chunks.Count == 0)
+            {
+                Logger.Warning($"AFK Journey lpak {fullName} did not contain valid UnityFS chunks. Falling back to normal loading.");
+                return false;
+            }
+
+            Logger.Info($"Loading AFK Journey lpak {fullName} ({chunks.Count} UnityFS chunks)");
+            try
+            {
+                using var stream = File.Open(fullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                Progress.Reset();
+                for (var i = 0; i < chunks.Count; i++)
+                {
+                    var chunk = chunks[i];
+                    var chunkPath = AFKJourneyUtils.GetLpakChunkVirtualPath(fullName, chunk);
+                    Logger.Verbose($"Loading AFK Journey lpak chunk {i + 1}/{chunks.Count} at 0x{chunk.Offset:X8}, size 0x{chunk.Size:X8}");
+                    var chunkStream = new BoundedStream(stream, chunk.Offset, chunk.Size, leaveOpen: true);
+                    var reader = new FileReader(chunkPath, chunkStream);
+                    LoadGameBlockFile(reader, fullName, chunk.Offset, false);
+                    Progress.Report(i + 1, chunks.Count);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Error($"Error while reading AFK Journey lpak {fullName}", e);
+            }
+
+            return true;
         }
 
         private void LoadFile(FileReader reader)

--- a/AnimeStudio/BoundedStream.cs
+++ b/AnimeStudio/BoundedStream.cs
@@ -1,0 +1,119 @@
+using System;
+using System.IO;
+
+namespace AnimeStudio
+{
+    public sealed class BoundedStream : Stream
+    {
+        private readonly Stream baseStream;
+        private readonly long start;
+        private readonly long length;
+        private readonly bool leaveOpen;
+        private long position;
+
+        public BoundedStream(Stream baseStream, long start, long length, bool leaveOpen = false)
+        {
+            if (baseStream == null)
+            {
+                throw new ArgumentNullException(nameof(baseStream));
+            }
+            if (!baseStream.CanRead || !baseStream.CanSeek)
+            {
+                throw new ArgumentException("Base stream must be readable and seekable.", nameof(baseStream));
+            }
+            if (start < 0 || length < 0 || start > baseStream.Length || length > baseStream.Length - start)
+            {
+                throw new ArgumentOutOfRangeException(nameof(start), "Bounded stream range is outside the base stream.");
+            }
+
+            this.baseStream = baseStream;
+            this.start = start;
+            this.length = length;
+            this.leaveOpen = leaveOpen;
+        }
+
+        public override bool CanRead => baseStream.CanRead;
+        public override bool CanSeek => baseStream.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => length;
+
+        public override long Position
+        {
+            get => position;
+            set => Seek(value, SeekOrigin.Begin);
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ArgumentNullException.ThrowIfNull(buffer);
+            ArgumentOutOfRangeException.ThrowIfNegative(offset);
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+            if (offset > buffer.Length || count > buffer.Length - offset)
+            {
+                throw new ArgumentException("Offset and count exceed buffer length.");
+            }
+
+            if (position >= length)
+            {
+                return 0;
+            }
+
+            count = (int)Math.Min(count, length - position);
+            baseStream.Position = start + position;
+            var read = baseStream.Read(buffer, offset, count);
+            position += read;
+            return read;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            if (position >= length)
+            {
+                return 0;
+            }
+
+            var count = (int)Math.Min(buffer.Length, length - position);
+            baseStream.Position = start + position;
+            var read = baseStream.Read(buffer[..count]);
+            position += read;
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            var target = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => position + offset,
+                SeekOrigin.End => length + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+            };
+
+            if (target < 0 || target > length)
+            {
+                throw new IOException("Unable to seek outside the bounded stream range.");
+            }
+
+            position = target;
+            return position;
+        }
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !leaveOpen)
+            {
+                baseStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/AnimeStudio/Classes/Shader.cs
+++ b/AnimeStudio/Classes/Shader.cs
@@ -950,7 +950,7 @@ namespace AnimeStudio
         {
             var version = reader.version;
 
-            if ((version[0] > 2020 || (version[0] == 2020 && version[1] >= 2)) && version[0] < 6000) //2020.2 to 2021.x
+            if (version[0] > 2020 || (version[0] == 2020 && version[1] >= 2)) //2020.2 and up
             {
                 int numEditorDataHash = reader.ReadInt32();
                 m_EditorDataHash = new List<Hash128>();
@@ -1237,7 +1237,7 @@ namespace AnimeStudio
 
         public Shader(ObjectReader reader) : base(reader)
         {
-            if (version[0] >= 6000)
+            if (reader.Game.Type == GameType.AFKJourney && version[0] >= 6000)
             {
                 Logger.Verbose($"Skipping Shader manual parsing for Unity {version[0]}.{version[1]} and newer");
                 var remainingBytes = reader.byteSize - (reader.Position - reader.byteStart);

--- a/AnimeStudio/Classes/Shader.cs
+++ b/AnimeStudio/Classes/Shader.cs
@@ -950,7 +950,7 @@ namespace AnimeStudio
         {
             var version = reader.version;
 
-            if (version[0] > 2020 || (version[0] == 2020 && version[1] >= 2)) //2020.2 and up
+            if ((version[0] > 2020 || (version[0] == 2020 && version[1] >= 2)) && version[0] < 6000) //2020.2 to 2021.x
             {
                 int numEditorDataHash = reader.ReadInt32();
                 m_EditorDataHash = new List<Hash128>();
@@ -1237,6 +1237,18 @@ namespace AnimeStudio
 
         public Shader(ObjectReader reader) : base(reader)
         {
+            if (version[0] >= 6000)
+            {
+                Logger.Verbose($"Skipping Shader manual parsing for Unity {version[0]}.{version[1]} and newer");
+                var remainingBytes = reader.byteSize - (reader.Position - reader.byteStart);
+                if (remainingBytes > 0)
+                {
+                    reader.ReadBytes((int)remainingBytes);
+                }
+
+                return;
+            }
+
             if (version[0] == 5 && version[1] >= 5 || version[0] > 5) //5.5 and up
             {
                 try

--- a/AnimeStudio/Classes/Texture2D.cs
+++ b/AnimeStudio/Classes/Texture2D.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace AnimeStudio
 {
@@ -78,6 +79,16 @@ namespace AnimeStudio
 
         private static bool HasGNFTexture(SerializedType type) => type.Match("1D52BB98AA5F54C67C22C39E8B2E400F");
         private static bool HasExternalMipRelativeOffset(SerializedType type) => type.Match("1D52BB98AA5F54C67C22C39E8B2E400F", "5390A985F58D5524F95DB240E8789704");
+        private static bool TypeTreeHasField(SerializedType type, string fieldName)
+        {
+            if (type?.m_Type?.m_Nodes == null)
+            {
+                return true;
+            }
+
+            return type.m_Type.m_Nodes.Any(node => node.m_Name == fieldName);
+        }
+
         public Texture2D(ObjectReader reader) : base(reader)
         {
             m_Width = reader.ReadInt32();
@@ -113,7 +124,8 @@ namespace AnimeStudio
             {
                 var m_IgnoreMasterTextureLimit = reader.ReadBoolean();
             }
-            if (version[0] > 2022 || (version[0] == 2022 && version[1] >= 2)) //2022.2 and up
+            var hasMipmapLimitGroupName = TypeTreeHasField(reader.serializedType, "m_MipmapLimitGroupName");
+            if (hasMipmapLimitGroupName && (version[0] > 2022 || (version[0] == 2022 && version[1] >= 2))) //2022.2 and up
             {
                 reader.AlignStream(); //m_IgnoreMipmapLimit
                 var m_MipmapLimitGroupName = reader.ReadAlignedString();
@@ -166,9 +178,19 @@ namespace AnimeStudio
             {
                 var m_ColorSpace = reader.ReadInt32();
             }
-            if (version[0] > 2020 || (version[0] == 2020 && version[1] >= 2)) //2020.2 and up
+            var hasPlatformBlob = TypeTreeHasField(reader.serializedType, "m_PlatformBlob");
+            if (hasPlatformBlob && (version[0] > 2020 || (version[0] == 2020 && version[1] >= 2))) //2020.2 and up
             {
-                var m_PlatformBlob = reader.ReadUInt8Array();
+                var blobLength = reader.ReadInt32();
+                var remainingBytes = reader.byteSize - (reader.Position - reader.byteStart);
+                if (blobLength > 0 && blobLength <= remainingBytes)
+                {
+                    var m_PlatformBlob = reader.ReadBytes(blobLength);
+                }
+                else if (blobLength > 0)
+                {
+                    reader.Position -= 4;
+                }
                 reader.AlignStream();
             }
             var image_data_size = reader.ReadInt32();

--- a/AnimeStudio/Classes/Texture2D.cs
+++ b/AnimeStudio/Classes/Texture2D.cs
@@ -124,7 +124,7 @@ namespace AnimeStudio
             {
                 var m_IgnoreMasterTextureLimit = reader.ReadBoolean();
             }
-            var hasMipmapLimitGroupName = TypeTreeHasField(reader.serializedType, "m_MipmapLimitGroupName");
+            var hasMipmapLimitGroupName = reader.Game.Type != GameType.AFKJourney || TypeTreeHasField(reader.serializedType, "m_MipmapLimitGroupName");
             if (hasMipmapLimitGroupName && (version[0] > 2022 || (version[0] == 2022 && version[1] >= 2))) //2022.2 and up
             {
                 reader.AlignStream(); //m_IgnoreMipmapLimit
@@ -178,7 +178,7 @@ namespace AnimeStudio
             {
                 var m_ColorSpace = reader.ReadInt32();
             }
-            var hasPlatformBlob = TypeTreeHasField(reader.serializedType, "m_PlatformBlob");
+            var hasPlatformBlob = reader.Game.Type != GameType.AFKJourney || TypeTreeHasField(reader.serializedType, "m_PlatformBlob");
             if (hasPlatformBlob && (version[0] > 2020 || (version[0] == 2020 && version[1] >= 2))) //2020.2 and up
             {
                 var blobLength = reader.ReadInt32();

--- a/AnimeStudio/GameManager.cs
+++ b/AnimeStudio/GameManager.cs
@@ -71,7 +71,6 @@ namespace AnimeStudio
             Games.Add(index++, new Game(GameType.SchoolGirlStrikers, "Schoolgirl Strikers"));
             Games.Add(index++, new Game(GameType.ExAstris, "ExAstris"));
             Games.Add(index++, new Game(GameType.PerpetualNovelty, "Perpetual Novelty"));
-            Games.Add(index++, new Game(GameType.AFKJourney, "AFK Journey"));
             Games.Add(index++, new Game(GameType.RewindingCadence, "Rewinding Cadence"));
             
             // unity cn
@@ -89,9 +88,10 @@ namespace AnimeStudio
             }
 
             Games.Add(index++, new UnityCNGame(GameType.UnityCNCustomKey, new("UnityCN Custom Key", ""), GameCategory.Unity));
+            Games.Add(index++, new Game(GameType.AFKJourney, "AFK Journey"));
         }
         public static Game GetGameByType(GameType gameType) => Games.FirstOrDefault(x => x.Value.Type == gameType).Value;
-        public static Game GetGame(GameType gameType) => GetGame((int)gameType);
+        public static Game GetGame(GameType gameType) => GetGameByType(gameType);
         public static Game GetGame(int index)
         {
             if (!Games.TryGetValue(index, out var format))
@@ -236,7 +236,6 @@ namespace AnimeStudio
         SchoolGirlStrikers,
         ExAstris,
         PerpetualNovelty,
-        AFKJourney,
         PGR_GLB_KR,
         PGR_CN_JP_TW,
         Archeland_KalpaOfUniverse,
@@ -262,6 +261,7 @@ namespace AnimeStudio
         CatFantasy,
         UnityCNCustomKey,
         RewindingCadence,
+        AFKJourney,
     }
 
 

--- a/AnimeStudio/GameManager.cs
+++ b/AnimeStudio/GameManager.cs
@@ -71,6 +71,7 @@ namespace AnimeStudio
             Games.Add(index++, new Game(GameType.SchoolGirlStrikers, "Schoolgirl Strikers"));
             Games.Add(index++, new Game(GameType.ExAstris, "ExAstris"));
             Games.Add(index++, new Game(GameType.PerpetualNovelty, "Perpetual Novelty"));
+            Games.Add(index++, new Game(GameType.AFKJourney, "AFK Journey"));
             Games.Add(index++, new Game(GameType.RewindingCadence, "Rewinding Cadence"));
             
             // unity cn
@@ -235,6 +236,7 @@ namespace AnimeStudio
         SchoolGirlStrikers,
         ExAstris,
         PerpetualNovelty,
+        AFKJourney,
         PGR_GLB_KR,
         PGR_CN_JP_TW,
         Archeland_KalpaOfUniverse,


### PR DESCRIPTION
- add AFK Journey as a supported game
- support AFK Journey loose special files:
  - fake DXT texture files
  - encrypted/compressed .jsone files
  - supported .pkg extraction
- add preview/export support for loose AFK Journey assets
- improve Unity version seeding so stripped AFK Journey bundles load correctly