### PR TITLE
Fix HSR 4.4 map-build OOM and apphost bin\bin\... path stacking

### DIFF
--- a/AnimeStudio.Patcher/Program.cs
+++ b/AnimeStudio.Patcher/Program.cs
@@ -1,4 +1,4 @@
-﻿// taken from https://github.com/dnSpy/dnSpy/blob/master/Build/AppHostPatcher/Program.cs
+// taken from https://github.com/dnSpy/dnSpy/blob/master/Build/AppHostPatcher/Program.cs
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -82,20 +82,40 @@ namespace AppHostPatcher
                 }
 
                 var apphostExeBytes = File.ReadAllBytes(apphostExe);
-                int offset = GetOffset(apphostExeBytes, origPathBytes);
+
+                // Idempotent: already pointing at the desired relative path.
+                if (GetOffset(apphostExeBytes, newPathBytes, requirePathStart: true) >= 0)
+                {
+                    Console.WriteLine($"Already patched: '{newPath}'");
+                    return 0;
+                }
+
+                // Prefer an exact bare-dll match (fresh apphost). Do not match the dll name
+                // as a suffix of bin\...\dll — that stacked bin\ on every build.ps1 run.
+                int offset = GetOffset(apphostExeBytes, origPathBytes, requirePathStart: true);
                 if (offset < 0)
                 {
-                    Console.WriteLine($"Could not find original path '{origPath}'");
-                    return 1;
+                    // Recover from a previously stacked path (bin\bin\...\dll).
+                    offset = FindEmbeddedDllPathStart(apphostExeBytes, origPath);
+                    if (offset < 0)
+                    {
+                        Console.WriteLine($"Could not find original path '{origPath}'");
+                        return 1;
+                    }
                 }
                 if (offset + newPathBytes.Length > apphostExeBytes.Length)
                 {
                     Console.WriteLine($"New path is too long: {newPath}");
                     return 1;
                 }
+                // Zero the whole path slot so leftover bytes from a longer previous path
+                // (e.g. bin\bin\bin\foo.dll) cannot remain after a shorter rewrite.
+                for (int i = offset; i < Math.Min(offset + maxPathBytes, apphostExeBytes.Length); i++)
+                    apphostExeBytes[i] = 0;
                 for (int i = 0; i < newPathBytes.Length; i++)
                     apphostExeBytes[offset + i] = newPathBytes[i];
                 File.WriteAllBytes(apphostExe, apphostExeBytes);
+                Console.WriteLine($"Patched '{apphostExe}': -> '{newPath}'");
                 return 0;
             }
             catch (Exception ex)
@@ -105,7 +125,7 @@ namespace AppHostPatcher
             }
         }
 
-        static int GetOffset(byte[] bytes, byte[] pattern)
+        static int GetOffset(byte[] bytes, byte[] pattern, bool requirePathStart)
         {
             int si = 0;
             var b = pattern[0];
@@ -115,7 +135,64 @@ namespace AppHostPatcher
                 if (si < 0)
                     break;
                 if (Match(bytes, si, pattern))
-                    return si;
+                {
+                    if (!requirePathStart || IsPathStart(bytes, si))
+                        return si;
+                }
+                si++;
+            }
+            return -1;
+        }
+
+        static bool IsPathStart(byte[] bytes, int index)
+        {
+            if (index <= 0)
+                return true;
+            var prev = bytes[index - 1];
+            // Reject suffix matches inside an already-patched path
+            // (e.g. "AnimeStudio.CLI.dll" inside "bin\AnimeStudio.CLI.dll").
+            return prev != (byte)'\\' && prev != (byte)'/';
+        }
+
+        /// <summary>
+        /// Find dllFileName\0 that may sit after one or more "subdir\" prefixes, and return
+        /// the start of the full relative path (first subdir).
+        /// </summary>
+        static int FindEmbeddedDllPathStart(byte[] bytes, string dllFileName)
+        {
+            var dllBytes = Encoding.UTF8.GetBytes(dllFileName);
+            int si = 0;
+            while (si < bytes.Length)
+            {
+                si = Array.IndexOf(bytes, dllBytes[0], si);
+                if (si < 0)
+                    break;
+                if (si + dllBytes.Length < bytes.Length
+                    && Match(bytes, si, dllBytes)
+                    && bytes[si + dllBytes.Length] == 0)
+                {
+                    // Walk back over path segments separated by \ or /
+                    int start = si;
+                    while (start > 0 && (bytes[start - 1] == (byte)'\\' || bytes[start - 1] == (byte)'/'))
+                    {
+                        int sep = start - 1;
+                        int segEnd = sep;
+                        int segStart = segEnd;
+                        while (segStart > 0)
+                        {
+                            var c = bytes[segStart - 1];
+                            if (c == 0 || c == (byte)'\\' || c == (byte)'/')
+                                break;
+                            if (c < 32 || c > 126)
+                                break;
+                            segStart--;
+                        }
+                        if (segStart == segEnd)
+                            break;
+                        start = segStart;
+                    }
+                    return start;
+                }
                 si++;
             }
             return -1;

--- a/AnimeStudio/AssetMap.cs
+++ b/AnimeStudio/AssetMap.cs
@@ -9,6 +9,7 @@ namespace AnimeStudio
     public static class StringCache
     {
         private static readonly HashSet<string> _cache = new(StringComparer.Ordinal);
+
         public static string Get(string value)
         {
             if (value == null) return null;
@@ -19,6 +20,17 @@ namespace AnimeStudio
             _cache.Add(value);
             return value;
         }
+
+        /// <summary>
+        /// Drop interned strings. Call between map-build files so unique asset names
+        /// from already-flushed entries do not accumulate across an entire game dump.
+        /// </summary>
+        public static void Clear()
+        {
+            _cache.Clear();
+        }
+
+        public static int Count => _cache.Count;
     }
 
     [MessagePackObject]
@@ -37,11 +49,13 @@ namespace AnimeStudio
         private string _source;
         private string _hash;
 
+        // Names are usually unique per asset — interning them only grows the cache.
         [Key(0)]
-        public string Name { 
+        public string Name {
             get => _name;
-            set => _name = StringCache.Get(value); 
+            set => _name = value;
         }
+        // Containers and sources repeat heavily across entries; keep interning those.
         [Key(1)]
         public string Container {
             get => _container;
@@ -56,10 +70,11 @@ namespace AnimeStudio
         public long PathID { get; set; }
         [Key(4)]
         public ClassIDType Type { get; set; }
+        // Hash is effectively unique per asset — interning it only grows the cache without reuse.
         [Key(5)]
         public string Hash {
             get => _hash;
-            set => _hash = StringCache.Get(value);
+            set => _hash = value;
         }
         [Key(6)]
         public long Offset { get; set; } = -1;

--- a/AnimeStudio/AssetsHelper.cs
+++ b/AnimeStudio/AssetsHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
@@ -156,10 +157,7 @@ namespace AnimeStudio
                 var collision = 0;
                 BaseFolder = baseFolder;
                 assetsManager.Game = game;
-                foreach (var file in LoadFiles(files))
-                {
-                    BuildCABMap(file, ref collision);
-                }
+                ForEachLoadedBundle(files, file => BuildCABMap(file, ref collision));
 
                 DumpCABMap(mapName);
 
@@ -171,11 +169,15 @@ namespace AnimeStudio
             }
         }
 
-        private static IEnumerable<string> LoadFiles(string[] files)
+        /// <summary>
+        /// Walk input files and invoke <paramref name="process"/> each time a bundle has been
+        /// loaded. For multi-bundle blocks (HSR ENCR .block) this fires once per inner bundle
+        /// so callers can flush map entries and release streams before the next bundle loads.
+        /// </summary>
+        private static void ForEachLoadedBundle(string[] files, Action<string> process)
         {
-            string msg;
-            
             var path = Path.GetDirectoryName(Path.GetFullPath(files[0]));
+            // Merge splits once for the whole batch — not once per file inside AssetsManager.LoadFiles.
             ImportHelper.MergeSplitAssets(path);
             var toReadFile = ImportHelper.ProcessingSplitFiles(files.ToList());
 
@@ -183,19 +185,71 @@ namespace AnimeStudio
             for (int i = 0; i < filesList.Count; i++)
             {
                 var file = filesList[i];
-                assetsManager.LoadFiles(file);
-                if (assetsManager.assetsFileList.Count > 0)
+                var processedViaCallback = false;
+
+                assetsManager.AfterBundleLoaded = () =>
                 {
-                    yield return file;
-                    msg = $"Processed {Path.GetFileName(file)}";
-                }
-                else
+                    // Always run for any loaded content. Resource-only bundles previously
+                    // skipped this path, so their streams (and the shared decompressed
+                    // block buffer they pin via zero-copy views) accumulated across every
+                    // ENCR in a multi-bundle HSR .block — the OOM after ~file 3580.
+                    if (assetsManager.assetsFileList.Count == 0
+                        && assetsManager.ResourceFileCount == 0)
+                    {
+                        return;
+                    }
+                    processedViaCallback = true;
+                    if (assetsManager.assetsFileList.Count > 0)
+                    {
+                        process(file);
+                    }
+                    // Free CAB/resource streams before the next bundle in this block loads.
+                    // Keep assetsFileListHash so duplicate CAB names in later bundles are skipped.
+                    assetsManager.ClearLoadedAssets();
+                    // Drop interned Container/Source strings from the bundle we just flushed.
+                    // A single HSR .block can contain 100+ ENCRs; without this the cache grows
+                    // for the entire outer file and pins multi-GB of unique path strings.
+                    StringCache.Clear();
+                    // Multi-bundle HSR blocks decompress LOH buffers per ENCR. Without an
+                    // explicit gen-2 collection those buffers stay alive until a later GC,
+                    // and private bytes climb by tens of MB × hundreds of ENCRs (OOM).
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, blocking: false, compacting: false);
+                };
+
+                try
                 {
-                    msg = $"Removed {Path.GetFileName(file)}, no assets found";
+                    assetsManager.LoadFiles(new[] { file }, mergeSplitAssets: false);
                 }
+                finally
+                {
+                    assetsManager.AfterBundleLoaded = null;
+                }
+
+                // Non-bundle assets files never trip AfterBundleLoaded — process once here.
+                if (!processedViaCallback && assetsManager.assetsFileList.Count > 0)
+                {
+                    process(file);
+                    processedViaCallback = true;
+                }
+
+                var msg = processedViaCallback
+                    ? $"Processed {Path.GetFileName(file)}"
+                    : $"Removed {Path.GetFileName(file)}, no assets found";
                 Logger.Info($"[{i + 1}/{filesList.Count}] {msg}");
                 Progress.Report(i + 1, filesList.Count);
                 assetsManager.Clear();
+
+                // Drop interned Source/Container strings from already-flushed entries so the
+                // cache cannot grow without bound across multi-thousand-file HSR dumps.
+                StringCache.Clear();
+
+                // Large multi-bundle blocks (HSR .block) allocate many LOH streams per file.
+                // A periodic gen-2 collection keeps the working set from ratcheting up across
+                // thousands of files until the OS OOM-kills the process.
+                if ((i + 1) % 32 == 0)
+                {
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, blocking: false, compacting: false);
+                }
             }
         }
 
@@ -326,21 +380,144 @@ namespace AnimeStudio
             {
                 Progress.Reset();
                 assetsManager.Game = game;
-                var assets = new List<AssetEntry>();
-                foreach (var file in LoadFiles(files))
+
+                // Genshin needs a full in-memory list so containers can be rewritten after the scan.
+                // Everyone else (HSR/ZZZ/…) streams entries out so peak RAM stays flat.
+                if (game.Type.IsGISubGroup() || exportListType.HasFlag(ExportListType.JSON))
                 {
-                    BuildAssetMap(file, assets, typeFilters, nameFilters, containerFilters);
+                    var assets = new List<AssetEntry>();
+                    ForEachLoadedBundle(files, file => BuildAssetMap(file, assets, typeFilters, nameFilters, containerFilters));
+                    UpdateContainers(assets, game);
+                    await ExportAssetsMap(assets, game, mapName, savePath, exportListType);
                 }
-
-                UpdateContainers(assets, game);
-
-                await ExportAssetsMap(assets, game, mapName, savePath, exportListType);
+                else
+                {
+                    await Task.Run(() => BuildAssetMapStreaming(files, mapName, game, savePath, exportListType, typeFilters, nameFilters, containerFilters));
+                }
             }
             catch(Exception e)
             {
                 Logger.Warning($"AssetMap was not build, {e}");
             }
-            
+
+        }
+
+        /// <summary>
+        /// Stream asset-map entries to disk while scanning so we never hold tens of millions of
+        /// AssetEntry objects in RAM (the HSR OOM root cause for full-directory map builds).
+        /// </summary>
+        private static void BuildAssetMapStreaming(string[] files, string mapName, Game game, string savePath, ExportListType exportListType, ClassIDType[] typeFilters, Regex[] nameFilters, Regex[] containerFilters)
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            Directory.CreateDirectory(savePath);
+
+            var entryCount = 0L;
+            var mpOptions = MessagePackSerializerOptions.Standard;
+            string tempEntriesPath = null;
+            FileStream tempEntries = null;
+            XmlWriter xmlWriter = null;
+            string xmlPath = null;
+            string mapPath = null;
+
+            try
+            {
+                if (exportListType.HasFlag(ExportListType.MessagePack))
+                {
+                    tempEntriesPath = Path.Combine(Path.GetTempPath(), $"animestudio-map-{Guid.NewGuid():N}.tmp");
+                    tempEntries = new FileStream(tempEntriesPath, FileMode.Create, FileAccess.Write, FileShare.None, 1024 * 64, FileOptions.SequentialScan);
+                    mapPath = Path.Combine(savePath, $"{mapName}.map");
+                }
+                if (exportListType.HasFlag(ExportListType.XML))
+                {
+                    xmlPath = Path.Combine(savePath, $"{mapName}.xml");
+                    xmlWriter = XmlWriter.Create(xmlPath, new XmlWriterSettings { Indent = true });
+                    xmlWriter.WriteStartDocument();
+                    xmlWriter.WriteStartElement("Assets");
+                    xmlWriter.WriteAttributeString("filename", xmlPath);
+                    xmlWriter.WriteAttributeString("createdAt", DateTime.UtcNow.ToString("s"));
+                }
+                if (exportListType.Equals(ExportListType.None))
+                {
+                    Logger.Info("No export list type has been selected, counting assets only...");
+                }
+
+                var batch = new List<AssetEntry>(256);
+                ForEachLoadedBundle(files, file =>
+                {
+                    batch.Clear();
+                    BuildAssetMap(file, batch, typeFilters, nameFilters, containerFilters);
+                    foreach (var asset in batch)
+                    {
+                        entryCount++;
+                        if (tempEntries != null)
+                        {
+                            MessagePackSerializer.Serialize(tempEntries, asset, mpOptions);
+                        }
+                        if (xmlWriter != null)
+                        {
+                            xmlWriter.WriteStartElement("Asset");
+                            xmlWriter.WriteElementString("Name", asset.Name);
+                            xmlWriter.WriteElementString("Container", asset.Container);
+                            xmlWriter.WriteStartElement("Type");
+                            xmlWriter.WriteAttributeString("id", ((int)asset.Type).ToString());
+                            xmlWriter.WriteValue(asset.Type.ToString());
+                            xmlWriter.WriteEndElement();
+                            xmlWriter.WriteElementString("PathID", asset.PathID.ToString());
+                            xmlWriter.WriteElementString("Source", asset.Source);
+                            xmlWriter.WriteEndElement();
+                        }
+                    }
+                });
+
+                if (xmlWriter != null)
+                {
+                    xmlWriter.WriteEndElement();
+                    xmlWriter.WriteEndDocument();
+                    xmlWriter.Flush();
+                }
+
+                if (tempEntries != null)
+                {
+                    tempEntries.Flush();
+                    tempEntries.Dispose();
+                    tempEntries = null;
+
+                    // Assemble final MessagePack AssetMap = [GameType, AssetEntries[]]
+                    // Uncompressed payload; MessagePack's Lz4BlockArray reader still accepts it.
+                    using var output = new FileStream(mapPath, FileMode.Create, FileAccess.Write, FileShare.None, 1024 * 64);
+                    var header = new ArrayBufferWriter<byte>(16);
+                    var writer = new MessagePackWriter(header);
+                    writer.WriteArrayHeader(2);
+                    writer.Write((int)game.Type);
+                    if (entryCount > int.MaxValue)
+                    {
+                        throw new InvalidOperationException($"Asset map has {entryCount} entries which exceeds MessagePack array limits.");
+                    }
+                    writer.WriteArrayHeader((int)entryCount);
+                    writer.Flush();
+                    output.Write(header.WrittenSpan);
+
+                    using (var input = new FileStream(tempEntriesPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1024 * 64, FileOptions.SequentialScan | FileOptions.DeleteOnClose))
+                    {
+                        input.CopyTo(output);
+                    }
+                    tempEntriesPath = null; // DeleteOnClose handled it
+                }
+
+                if (!exportListType.Equals(ExportListType.None))
+                {
+                    Logger.Info($"Finished buidling AssetMap with {entryCount} assets.");
+                }
+            }
+            finally
+            {
+                xmlWriter?.Dispose();
+                tempEntries?.Dispose();
+                if (tempEntriesPath != null && File.Exists(tempEntriesPath))
+                {
+                    try { File.Delete(tempEntriesPath); } catch { /* best-effort */ }
+                }
+            }
         }
 
         private static void BuildAssetMap(string file, List<AssetEntry> assets, ClassIDType[] typeFilters = null, Regex[] nameFilters = null, Regex[] containerFilters = null)
@@ -361,13 +538,15 @@ namespace AnimeStudio
                     }
                     var objectReader = new ObjectReader(assetsFile.reader, assetsFile, objInfo, assetsManager.Game);
                     var obj = new Object(objectReader);
+                    // Keep a stable reference for hashing — some branches below set obj = null
+                    // (AssetBundle / IndexObject) while the entry may still be exportable.
+                    var hashSource = obj;
                     var asset = new AssetEntry()
                     {
                         Source = file,
                         PathID = objectReader.m_PathID,
                         Type = objectReader.type,
                         Container = "",
-                        Hash = obj.GetHash(),
                         Offset = assetsFile.offset
                     };
 
@@ -410,8 +589,11 @@ namespace AnimeStudio
                                 asset.Name = objectReader.ReadAlignedString();
                                 if (string.IsNullOrEmpty(asset.Name))
                                 {
-                                    var m_parsedForm = new SerializedShader(objectReader);
-                                    asset.Name = m_parsedForm.m_Name;
+                                    // Do NOT run full SerializedShader parsing during map builds.
+                                    // HSR ships individual shaders >100MB; the nested parse allocates
+                                    // multi-GB of temporary structures and is what OOMs map builds
+                                    // around multi-bundle blocks (e.g. after file ~3580).
+                                    asset.Name = $"Shader #{objectReader.m_PathID}";
                                 }
 
                                 exportable = ClassIDType.Shader.CanExport();
@@ -486,6 +668,13 @@ namespace AnimeStudio
                     }
                     if (exportable)
                     {
+                        // Hash only exportable entries. Skip multi-dozen-MB blobs (large HSR
+                        // shaders/meshes): streaming hash is correct but pointless for map
+                        // identity when the raw payload dwarfs the rest of the entry.
+                        const uint largeHashSkip = 16u * 1024 * 1024;
+                        asset.Hash = hashSource.byteSize >= largeHashSkip
+                            ? $"size:{hashSource.byteSize:x}"
+                            : hashSource.GetHash();
                         matches.Add(asset);
                     }
                 }
@@ -717,23 +906,146 @@ namespace AnimeStudio
         public static async Task BuildBoth(string[] files, string mapName, string baseFolder, Game game, string savePath, ExportListType exportListType, ClassIDType[] typeFilters = null, Regex[] nameFilters = null, Regex[] containerFilters = null)
         {
             Logger.Info($"Building Both...");
-            CABMap.Clear();
-            Progress.Reset();
-            var collision = 0;
-            BaseFolder = baseFolder;
-            assetsManager.Game = game;
-            var assets = new List<AssetEntry>();
-            foreach(var file in LoadFiles(files))
+            try
             {
-                BuildCABMap(file, ref collision);
-                BuildAssetMap(file, assets, typeFilters, nameFilters, containerFilters);
+                CABMap.Clear();
+                Progress.Reset();
+                var collision = 0;
+                BaseFolder = baseFolder;
+                assetsManager.Game = game;
+
+                if (game.Type.IsGISubGroup() || exportListType.HasFlag(ExportListType.JSON))
+                {
+                    var assets = new List<AssetEntry>();
+                    ForEachLoadedBundle(files, file =>
+                    {
+                        BuildCABMap(file, ref collision);
+                        BuildAssetMap(file, assets, typeFilters, nameFilters, containerFilters);
+                    });
+                    UpdateContainers(assets, game);
+                    DumpCABMap(mapName);
+                    Logger.Info($"Map build successfully !! {collision} collisions found");
+                    await ExportAssetsMap(assets, game, mapName, savePath, exportListType);
+                }
+                else
+                {
+                    // Stream asset entries while still collecting CAB map in memory (small).
+                    await Task.Run(() =>
+                    {
+                        Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+                        Directory.CreateDirectory(savePath);
+
+                        var entryCount = 0L;
+                        var mpOptions = MessagePackSerializerOptions.Standard;
+                        string tempEntriesPath = null;
+                        FileStream tempEntries = null;
+                        XmlWriter xmlWriter = null;
+                        string mapPath = null;
+
+                        try
+                        {
+                            if (exportListType.HasFlag(ExportListType.MessagePack))
+                            {
+                                tempEntriesPath = Path.Combine(Path.GetTempPath(), $"animestudio-map-{Guid.NewGuid():N}.tmp");
+                                tempEntries = new FileStream(tempEntriesPath, FileMode.Create, FileAccess.Write, FileShare.None, 1024 * 64, FileOptions.SequentialScan);
+                                mapPath = Path.Combine(savePath, $"{mapName}.map");
+                            }
+                            if (exportListType.HasFlag(ExportListType.XML))
+                            {
+                                var xmlPath = Path.Combine(savePath, $"{mapName}.xml");
+                                xmlWriter = XmlWriter.Create(xmlPath, new XmlWriterSettings { Indent = true });
+                                xmlWriter.WriteStartDocument();
+                                xmlWriter.WriteStartElement("Assets");
+                                xmlWriter.WriteAttributeString("filename", xmlPath);
+                                xmlWriter.WriteAttributeString("createdAt", DateTime.UtcNow.ToString("s"));
+                            }
+
+                            var batch = new List<AssetEntry>(256);
+                            ForEachLoadedBundle(files, file =>
+                            {
+                                BuildCABMap(file, ref collision);
+                                batch.Clear();
+                                BuildAssetMap(file, batch, typeFilters, nameFilters, containerFilters);
+                                foreach (var asset in batch)
+                                {
+                                    entryCount++;
+                                    if (tempEntries != null)
+                                    {
+                                        MessagePackSerializer.Serialize(tempEntries, asset, mpOptions);
+                                    }
+                                    if (xmlWriter != null)
+                                    {
+                                        xmlWriter.WriteStartElement("Asset");
+                                        xmlWriter.WriteElementString("Name", asset.Name);
+                                        xmlWriter.WriteElementString("Container", asset.Container);
+                                        xmlWriter.WriteStartElement("Type");
+                                        xmlWriter.WriteAttributeString("id", ((int)asset.Type).ToString());
+                                        xmlWriter.WriteValue(asset.Type.ToString());
+                                        xmlWriter.WriteEndElement();
+                                        xmlWriter.WriteElementString("PathID", asset.PathID.ToString());
+                                        xmlWriter.WriteElementString("Source", asset.Source);
+                                        xmlWriter.WriteEndElement();
+                                    }
+                                }
+                            });
+
+                            DumpCABMap(mapName);
+
+                            if (xmlWriter != null)
+                            {
+                                xmlWriter.WriteEndElement();
+                                xmlWriter.WriteEndDocument();
+                                xmlWriter.Flush();
+                            }
+
+                            if (tempEntries != null)
+                            {
+                                tempEntries.Flush();
+                                tempEntries.Dispose();
+                                tempEntries = null;
+
+                                using var output = new FileStream(mapPath, FileMode.Create, FileAccess.Write, FileShare.None, 1024 * 64);
+                                var header = new ArrayBufferWriter<byte>(16);
+                                var writer = new MessagePackWriter(header);
+                                writer.WriteArrayHeader(2);
+                                writer.Write((int)game.Type);
+                                if (entryCount > int.MaxValue)
+                                {
+                                    throw new InvalidOperationException($"Asset map has {entryCount} entries which exceeds MessagePack array limits.");
+                                }
+                                writer.WriteArrayHeader((int)entryCount);
+                                writer.Flush();
+                                output.Write(header.WrittenSpan);
+
+                                using (var input = new FileStream(tempEntriesPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1024 * 64, FileOptions.SequentialScan | FileOptions.DeleteOnClose))
+                                {
+                                    input.CopyTo(output);
+                                }
+                                tempEntriesPath = null;
+                            }
+
+                            Logger.Info($"Map build successfully !! {collision} collisions found");
+                            if (!exportListType.Equals(ExportListType.None))
+                            {
+                                Logger.Info($"Finished buidling AssetMap with {entryCount} assets.");
+                            }
+                        }
+                        finally
+                        {
+                            xmlWriter?.Dispose();
+                            tempEntries?.Dispose();
+                            if (tempEntriesPath != null && File.Exists(tempEntriesPath))
+                            {
+                                try { File.Delete(tempEntriesPath); } catch { /* best-effort */ }
+                            }
+                        }
+                    });
+                }
             }
-
-            UpdateContainers(assets, game);
-            DumpCABMap(mapName);
-
-            Logger.Info($"Map build successfully !! {collision} collisions found");
-            await ExportAssetsMap(assets, game, mapName, savePath, exportListType);
+            catch (Exception e)
+            {
+                Logger.Warning($"Map was not build, {e}");
+            }
         }
     }
 }

--- a/AnimeStudio/AssetsHelper.cs
+++ b/AnimeStudio/AssetsHelper.cs
@@ -506,7 +506,7 @@ namespace AnimeStudio
 
                 if (!exportListType.Equals(ExportListType.None))
                 {
-                    Logger.Info($"Finished buidling AssetMap with {entryCount} assets.");
+                    Logger.Info($"Finished building AssetMap with {entryCount} assets.");
                 }
             }
             finally
@@ -899,7 +899,7 @@ namespace AnimeStudio
                         MessagePackSerializer.Serialize(file, assetMap, MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray));
                     }
 
-                    Logger.Info($"Finished buidling AssetMap with {toExportAssets.Count} assets.");
+                    Logger.Info($"Finished building AssetMap with {toExportAssets.Count} assets.");
                 }
             });
         }
@@ -1027,7 +1027,7 @@ namespace AnimeStudio
                             Logger.Info($"Map build successfully !! {collision} collisions found");
                             if (!exportListType.Equals(ExportListType.None))
                             {
-                                Logger.Info($"Finished buidling AssetMap with {entryCount} assets.");
+                                Logger.Info($"Finished building AssetMap with {entryCount} assets.");
                             }
                         }
                         finally

--- a/AnimeStudio/AssetsManager.cs
+++ b/AnimeStudio/AssetsManager.cs
@@ -15,8 +15,17 @@ namespace AnimeStudio
         public Game Game;
         public bool Silent = false;
         public bool SkipProcess = false;
-        public bool ResolveDependencies = false;        
+        public bool ResolveDependencies = false;
         public string SpecifyUnityVersion;
+        /// <summary>
+        /// Invoked after each bundle/CAB group is loaded from a multi-bundle block.
+        /// Used by map builders to process + release streams before the next bundle
+        /// so peak RAM stays proportional to one bundle instead of the whole .block.
+        /// </summary>
+        public Action AfterBundleLoaded;
+
+        /// <summary>Number of cached resource streams (for map-builder flush decisions).</summary>
+        public int ResourceFileCount => resourceFileReaders.Count;
         public CancellationTokenSource tokenSource = new CancellationTokenSource();
         public List<SerializedFile> assetsFileList = new List<SerializedFile>();
 
@@ -64,15 +73,33 @@ namespace AnimeStudio
 
         public void LoadFiles(params string[] files)
         {
+            LoadFiles(files, mergeSplitAssets: true);
+        }
+
+        /// <param name="mergeSplitAssets">
+        /// When false, skips <see cref="ImportHelper.MergeSplitAssets"/> / split-file filtering.
+        /// Map builders already do that once up front; repeating it per file re-scans huge directories (HSR).
+        /// </param>
+        public void LoadFiles(string[] files, bool mergeSplitAssets)
+        {
             if (Silent)
             {
                 Logger.Silent = true;
                 Progress.Silent = true;
             }
 
-            var path = Path.GetDirectoryName(Path.GetFullPath(files[0]));
-            MergeSplitAssets(path);
-            var toReadFile = ProcessingSplitFiles(files.ToList());
+            string[] toReadFile;
+            if (mergeSplitAssets)
+            {
+                var path = Path.GetDirectoryName(Path.GetFullPath(files[0]));
+                MergeSplitAssets(path);
+                toReadFile = ProcessingSplitFiles(files.ToList());
+            }
+            else
+            {
+                toReadFile = files;
+            }
+
             if (ResolveDependencies)
                 toReadFile = AssetsHelper.ProcessDependencies(toReadFile);
             Load(toReadFile);
@@ -224,34 +251,41 @@ namespace AnimeStudio
                     assetsFileIndexCache.Add(assetsFile.fileName, assetsFileList.Count - 1);
                     assetsFileListHash.Add(assetsFile.fileName);
 
-                    foreach (var sharedFile in assetsFile.m_Externals)
+                    // External lookup does recursive Directory.GetFiles scans. Skip it when
+                    // dependencies are not being resolved (map builds, single-file loads) —
+                    // HSR-style CAB externals are almost never real on-disk files and the
+                    // repeated full-directory scans dominate both CPU and temporary allocations.
+                    if (ResolveDependencies)
                     {
-                        Logger.Verbose($"{assetsFile.fileName} needs external file {sharedFile.fileName}, attempting to look it up...");
-                        var sharedFileName = sharedFile.fileName;
-
-                        if (!importFilesHash.Contains(sharedFileName))
+                        foreach (var sharedFile in assetsFile.m_Externals)
                         {
-                            var sharedFilePath = Path.Combine(Path.GetDirectoryName(reader.FullPath), sharedFileName);
-                            if (!noexistFiles.Contains(sharedFilePath))
+                            Logger.Verbose($"{assetsFile.fileName} needs external file {sharedFile.fileName}, attempting to look it up...");
+                            var sharedFileName = sharedFile.fileName;
+
+                            if (!importFilesHash.Contains(sharedFileName))
                             {
-                                if (!File.Exists(sharedFilePath))
+                                var sharedFilePath = Path.Combine(Path.GetDirectoryName(reader.FullPath), sharedFileName);
+                                if (!noexistFiles.Contains(sharedFilePath))
                                 {
-                                    var findFiles = Directory.GetFiles(Path.GetDirectoryName(reader.FullPath), sharedFileName, SearchOption.AllDirectories);
-                                    if (findFiles.Length > 0)
+                                    if (!File.Exists(sharedFilePath))
                                     {
-                                        Logger.Verbose($"Found {findFiles.Length} matching files, picking first file {findFiles[0]} !!");
-                                        sharedFilePath = findFiles[0];
+                                        var findFiles = Directory.GetFiles(Path.GetDirectoryName(reader.FullPath), sharedFileName, SearchOption.AllDirectories);
+                                        if (findFiles.Length > 0)
+                                        {
+                                            Logger.Verbose($"Found {findFiles.Length} matching files, picking first file {findFiles[0]} !!");
+                                            sharedFilePath = findFiles[0];
+                                        }
                                     }
-                                }
-                                if (File.Exists(sharedFilePath))
-                                {
-                                    importFiles.Add(sharedFilePath);
-                                    importFilesHash.Add(sharedFileName);
-                                }
-                                else
-                                {
-                                    Logger.Verbose("Nothing was found, caching into non existant files to avoid repeated searching !!");
-                                    noexistFiles.Add(sharedFilePath);
+                                    if (File.Exists(sharedFilePath))
+                                    {
+                                        importFiles.Add(sharedFilePath);
+                                        importFilesHash.Add(sharedFileName);
+                                    }
+                                    else
+                                    {
+                                        Logger.Verbose("Nothing was found, caching into non existant files to avoid repeated searching !!");
+                                        noexistFiles.Add(sharedFilePath);
+                                    }
                                 }
                             }
                         }
@@ -292,11 +326,20 @@ namespace AnimeStudio
                 catch (Exception e)
                 {
                     Logger.Error($"Error while reading assets file {reader.FullPath} from {Path.GetFileName(originalPath)}", e);
-                    resourceFileReaders.TryAdd(reader.FileName, reader);
+                    // Only retain the reader if we actually cache it; otherwise free its stream.
+                    if (!resourceFileReaders.TryAdd(reader.FileName, reader))
+                    {
+                        reader.Dispose();
+                    }
                 }
             }
             else
+            {
                 Logger.Info($"Skipping {originalPath} ({reader.FileName})");
+                // Duplicate CAB name inside the same block (or already loaded) — the stream was
+                // freshly allocated by BundleFile.ReadFiles and would otherwise leak until GC.
+                reader.Dispose();
+            }
         }
 
         private void LoadWebFile(FileReader reader)
@@ -322,7 +365,10 @@ namespace AnimeStudio
                             break;
                         case FileType.ResourceFile:
                             Logger.Verbose("Caching resource stream");
-                            resourceFileReaders.TryAdd(file.fileName, subReader); //TODO
+                            if (!resourceFileReaders.TryAdd(file.fileName, subReader))
+                            {
+                                subReader.Dispose();
+                            }
                             break;
                     }
                 }
@@ -415,7 +461,10 @@ namespace AnimeStudio
                             {
                                 entryReader.Position = 0;
                                 Logger.Verbose("Caching resource file");
-                                resourceFileReaders.TryAdd(entry.Name, entryReader);
+                                if (!resourceFileReaders.TryAdd(entry.Name, entryReader))
+                                {
+                                    entryReader.Dispose();
+                                }
                             }
                         }
                         catch (Exception e)
@@ -538,7 +587,12 @@ namespace AnimeStudio
                     else
                     {
                         Logger.Verbose("Caching resource stream");
-                        resourceFileReaders.TryAdd(innerFile.fileName, cabReader); //TODO
+                        // Dispose immediately on name collision — TryAdd would otherwise drop the
+                        // new stream with no owner while the previous one stays cached.
+                        if (!resourceFileReaders.TryAdd(innerFile.fileName, cabReader))
+                        {
+                            cabReader.Dispose();
+                        }
                     }
                 }
             }
@@ -578,6 +632,8 @@ namespace AnimeStudio
             finally
             {
                 reader.Dispose();
+                // Notify map builders after each bundle so they can flush entries and free streams.
+                AfterBundleLoaded?.Invoke();
             }
         }
 
@@ -594,13 +650,18 @@ namespace AnimeStudio
             }
         }
 
-        public void Clear()
+        /// <summary>
+        /// Dispose loaded asset/resource streams but keep <see cref="assetsFileListHash"/>
+        /// so subsequent bundles in the same block still skip already-seen CAB names.
+        /// </summary>
+        public void ClearLoadedAssets()
         {
-            Logger.Verbose("Cleaning up...");
+            Logger.Verbose("Cleaning loaded assets...");
 
             foreach (var assetsFile in assetsFileList)
             {
                 assetsFile.Objects.Clear();
+                assetsFile.ObjectsDic.Clear();
                 assetsFile.reader.Close();
             }
             assetsFileList.Clear();
@@ -612,12 +673,18 @@ namespace AnimeStudio
             resourceFileReaders.Clear();
 
             assetsFileIndexCache.Clear();
+        }
+
+        public void Clear()
+        {
+            Logger.Verbose("Cleaning up...");
+
+            ClearLoadedAssets();
+            OffsetData.Clear();
+            assetsFileListHash.Clear();
 
             tokenSource.Dispose();
             tokenSource = new CancellationTokenSource();
-
-            // GC.WaitForPendingFinalizers();
-            // GC.Collect();
         }
 
         private void ReadAssets()

--- a/AnimeStudio/BundleFile.cs
+++ b/AnimeStudio/BundleFile.cs
@@ -261,17 +261,29 @@ namespace AnimeStudio
         private Stream CreateBlocksStream(string path)
         {
             Stream blocksStream;
-            var uncompressedSizeSum = m_BlocksInfo.Sum(x => x.uncompressedSize);
+            var uncompressedSizeSum = m_BlocksInfo.Sum(x => (long)x.uncompressedSize);
             Logger.Verbose($"Total size of decompressed blocks: {uncompressedSizeSum}");
-            if (uncompressedSizeSum >= int.MaxValue)
+
+            // Guard against corrupt/misaligned block info that would request multi-GB buffers.
+            // Real UnityFS blocks are rarely more than a few hundred MB decompressed.
+            const long maxInMemory = 512L * 1024 * 1024; // 512 MB
+            if (uncompressedSizeSum <= 0)
+            {
+                throw new InvalidDataException($"Invalid decompressed block size: {uncompressedSizeSum}");
+            }
+            if (uncompressedSizeSum >= int.MaxValue || uncompressedSizeSum > maxInMemory)
             {
                 /*var memoryMappedFile = MemoryMappedFile.CreateNew(null, uncompressedSizeSum);
                 assetsDataStream = memoryMappedFile.CreateViewStream();*/
+                Logger.Verbose($"Using temp file for large decompressed blocks ({uncompressedSizeSum} bytes)");
                 blocksStream = new FileStream(path + ".temp", FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose);
             }
             else
             {
-                blocksStream = new MemoryStream((int)uncompressedSizeSum);
+                // publiclyVisible so ReadFiles can slice CAB streams from the same buffer
+                // instead of allocating a second full copy of every node (halves peak RAM).
+                var buffer = GC.AllocateUninitializedArray<byte>((int)uncompressedSizeSum);
+                blocksStream = new MemoryStream(buffer, 0, buffer.Length, writable: true, publiclyVisible: true);
             }
             return blocksStream;
         }
@@ -313,6 +325,12 @@ namespace AnimeStudio
             Logger.Verbose($"Writing files from blocks stream...");
 
             fileList = new List<StreamFile>();
+            // Prefer zero-copy slices over the decompressed block buffer when possible.
+            ArraySegment<byte> shared = default;
+            bool hasShared = blocksStream is MemoryStream memoryStream
+                             && memoryStream.TryGetBuffer(out shared)
+                             && shared.Array != null;
+
             for (int i = 0; i < m_DirectoryInfo.Count; i++)
             {
                 var node = m_DirectoryInfo[i];
@@ -327,14 +345,31 @@ namespace AnimeStudio
                     var extractPath = path + "_unpacked" + Path.DirectorySeparatorChar;
                     Directory.CreateDirectory(extractPath);
                     file.stream = new FileStream(extractPath + file.fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+                    blocksStream.Position = node.offset;
+                    blocksStream.CopyTo(file.stream, node.size);
+                    file.stream.Position = 0;
+                }
+                else if (hasShared
+                         && node.offset >= 0
+                         && node.offset <= int.MaxValue
+                         && node.size <= int.MaxValue
+                         && node.offset + node.size <= shared.Count)
+                {
+                    // View into the shared decompressed buffer — no per-CAB copy.
+                    file.stream = new MemoryStream(
+                        shared.Array,
+                        shared.Offset + (int)node.offset,
+                        (int)node.size,
+                        writable: false,
+                        publiclyVisible: true);
                 }
                 else
                 {
                     file.stream = new MemoryStream((int)node.size);
+                    blocksStream.Position = node.offset;
+                    blocksStream.CopyTo(file.stream, node.size);
+                    file.stream.Position = 0;
                 }
-                blocksStream.Position = node.offset;
-                blocksStream.CopyTo(file.stream, node.size);
-                file.stream.Position = 0;
             }
         }
 
@@ -430,7 +465,18 @@ namespace AnimeStudio
             if ((m_Header.flags & ArchiveFlags.BlocksInfoAtTheEnd) != 0) //kArchiveBlocksInfoAtTheEnd
             {
                 var position = reader.Position;
-                reader.Position = reader.BaseStream.Length - m_Header.compressedBlocksInfoSize;
+                // Multi-bundle containers (HSR ENCR .block) share one outer stream. Using
+                // BaseStream.Length would seek to the end of the entire .block and parse the
+                // wrong trailer. Prefer header.size (bundle byte length from signature).
+                long bundleEnd = m_Header.size > 0
+                    ? m_Header.size
+                    : reader.BaseStream.Length;
+                if (bundleEnd <= m_Header.compressedBlocksInfoSize)
+                {
+                    throw new InvalidDataException(
+                        $"Bundle size {bundleEnd} is smaller than blocks-info size {m_Header.compressedBlocksInfoSize}");
+                }
+                reader.Position = bundleEnd - m_Header.compressedBlocksInfoSize;
                 blocksInfoBytes = reader.ReadBytes((int)m_Header.compressedBlocksInfoSize);
                 reader.Position = position;
             }
@@ -581,8 +627,18 @@ namespace AnimeStudio
                             var compressedSize = (int)blockInfo.compressedSize;
                             var uncompressedSize = (int)blockInfo.uncompressedSize;
 
-                            var compressedBytes = ArrayPool<byte>.Shared.Rent(compressedSize);
-                            var uncompressedBytes = ArrayPool<byte>.Shared.Rent(uncompressedSize);
+                            // Avoid ArrayPool for large blocks: Shared keeps returned buffers for
+                            // reuse, so walking 100+ HSR ENCRs would permanently retain the largest
+                            // (~100MB+) decompress buffers in the pool for the process lifetime.
+                            const int arrayPoolLimit = 1 * 1024 * 1024;
+                            var poolCompressed = compressedSize <= arrayPoolLimit;
+                            var poolUncompressed = uncompressedSize <= arrayPoolLimit;
+                            var compressedBytes = poolCompressed
+                                ? ArrayPool<byte>.Shared.Rent(compressedSize)
+                                : GC.AllocateUninitializedArray<byte>(compressedSize);
+                            var uncompressedBytes = poolUncompressed
+                                ? ArrayPool<byte>.Shared.Rent(uncompressedSize)
+                                : GC.AllocateUninitializedArray<byte>(uncompressedSize);
 
                             var compressedBytesSpan = compressedBytes.AsSpan(0, compressedSize);
                             var uncompressedBytesSpan = uncompressedBytes.AsSpan(0, uncompressedSize);
@@ -605,8 +661,10 @@ namespace AnimeStudio
                             finally
                             {
                                 blocksStream.Write(uncompressedBytesSpan);
-                                ArrayPool<byte>.Shared.Return(compressedBytes, true);
-                                ArrayPool<byte>.Shared.Return(uncompressedBytes, true);
+                                if (poolCompressed)
+                                    ArrayPool<byte>.Shared.Return(compressedBytes, true);
+                                if (poolUncompressed)
+                                    ArrayPool<byte>.Shared.Return(uncompressedBytes, true);
                             }
 
                             break;

--- a/AnimeStudio/Classes/Object.cs
+++ b/AnimeStudio/Classes/Object.cs
@@ -1,6 +1,7 @@
 ﻿using K4os.Hash.xxHash;
 using Newtonsoft.Json;
 using System;
+using System.Buffers;
 using System.Collections.Specialized;
 
 namespace AnimeStudio
@@ -39,7 +40,7 @@ namespace AnimeStudio
             buildType = reader.buildType;
             platform = reader.platform;
             serializedType = reader.serializedType;
-            byteSize = reader.byteSize;  
+            byteSize = reader.byteSize;
 
             Logger.Verbose($"Attempting to read object {type} with {m_PathID} in file {assetsFile.fileName}, starting from offset 0x{reader.byteStart:X8} with size of 0x{byteSize:X8} !!");
 
@@ -58,9 +59,44 @@ namespace AnimeStudio
                 var hash = Texture2DExtensions.GetImageHash(new Texture2D(reader));
                 reader.Position = pos;
                 return hash;
-            } else
+            }
+
+            return ComputeRawHash().ToString("x");
+        }
+
+        /// <summary>
+        /// Stream object bytes through xxHash without allocating a full raw-data buffer.
+        /// Avoids multi-GB LOH pressure when building asset maps over large games (e.g. HSR).
+        /// </summary>
+        private ulong ComputeRawHash()
+        {
+            Logger.Verbose($"Hashing raw bytes of the object with {m_PathID} in file {assetsFile.fileName}...");
+            long pos = reader.Position;
+            reader.Reset();
+
+            var hasher = new XXH64();
+            int remaining = (int)byteSize;
+            // 64KB chunks keep peak temporary memory flat regardless of object size.
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(0x10000);
+            try
             {
-                return XXH64.DigestOf(GetRawData()).ToString("x");
+                while (remaining > 0)
+                {
+                    int toRead = Math.Min(remaining, buffer.Length);
+                    int read = reader.Read(buffer, 0, toRead);
+                    if (read <= 0)
+                    {
+                        break;
+                    }
+                    hasher.Update(buffer, 0, read);
+                    remaining -= read;
+                }
+                return hasher.Digest();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+                reader.Position = pos;
             }
         }
 

--- a/AnimeStudio/EndianBinaryReader.cs
+++ b/AnimeStudio/EndianBinaryReader.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
@@ -116,23 +115,30 @@ namespace AnimeStudio
                 return Array.Empty<byte>();
             }
 
-            var buffer = ArrayPool<byte>.Shared.Rent(0x1000);
-            List<byte> result = new List<byte>(count);
-            do
+            // Single destination buffer — avoids List growth + final ToArray copy that
+            // previously doubled peak memory for large reads (object hashing, etc.).
+            var result = new byte[count];
+            int offset = 0;
+            int remaining = count;
+            while (remaining > 0)
             {
-                var readNum = Math.Min(count, buffer.Length);
-                int n = Read(buffer, 0, readNum);
+                int n = Read(result, offset, remaining);
                 if (n == 0)
                 {
+                    if (offset == 0)
+                    {
+                        return Array.Empty<byte>();
+                    }
+                    if (offset < count)
+                    {
+                        Array.Resize(ref result, offset);
+                    }
                     break;
                 }
-
-                result.AddRange(buffer[..n]);
-                count -= n;
-            } while (count > 0);
-
-            ArrayPool<byte>.Shared.Return(buffer);
-            return result.ToArray();
+                offset += n;
+                remaining -= n;
+            }
+            return result;
         }
 
         public void AlignStream()

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
 # prepare patcher
 dotnet build AnimeStudio.Patcher -c Release -f net10.0
+if ($LASTEXITCODE -ne 0) { throw "Patcher build failed" }
 $patcher = "AnimeStudio.Patcher\bin\Release\net10.0\AnimeStudio.Patcher.exe"
+if (-not (Test-Path $patcher)) { throw "Patcher not found at $patcher" }
+
+function Reset-Dir([string]$path) {
+    if (Test-Path $path) {
+        try {
+            Remove-Item $path -Recurse -Force -ErrorAction Stop
+        } catch {
+            # Directory may be locked (Explorer preview, running app). Clear contents instead.
+            Write-Warning "Could not remove '$path' wholesale; clearing contents. $_"
+            Get-ChildItem $path -Force | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+    New-Item -ItemType Directory -Force $path | Out-Null
+}
 
 foreach ($tfm in 'net9.0-windows', 'net10.0-windows') {
     # config
@@ -14,24 +31,69 @@ foreach ($tfm in 'net9.0-windows', 'net10.0-windows') {
     $guiExe = "$guiOut/AnimeStudio.GUI.exe"
     $cliExe = "$cliOut/AnimeStudio.CLI.exe"
 
+    # Force a fresh apphost so we never re-patch an already-patched exe in-place
+    # (old patcher stacked bin\ on each run; even fixed patcher needs a clean host once).
+    if (Test-Path $cliExe) { Remove-Item $cliExe -Force }
+    if (Test-Path $guiExe) { Remove-Item $guiExe -Force }
+
     # build cli and gui & patch them
     dotnet build AnimeStudio.CLI -c $configuration -f $tfm
+    if ($LASTEXITCODE -ne 0) { throw "CLI build failed ($tfm)" }
     & $patcher $cliExe -d bin
+    if ($LASTEXITCODE -ne 0) { throw "CLI patch failed ($tfm)" }
+
     dotnet build AnimeStudio.GUI -c $configuration -f $tfm
+    if ($LASTEXITCODE -ne 0) { throw "GUI build failed ($tfm)" }
     & $patcher $guiExe -d bin
+    if ($LASTEXITCODE -ne 0) { throw "GUI patch failed ($tfm)" }
+
+    # Ensure native FBX libs are present (SolutionDir is often empty for bare `dotnet build`)
+    foreach ($arch in 'x86', 'x64') {
+        $src = "AnimeStudio.Libraries\$arch\AnimeStudio.FBXNative.dll"
+        if (Test-Path $src) {
+            foreach ($out in @($cliOut, $guiOut)) {
+                $destDir = Join-Path $out $arch
+                New-Item -ItemType Directory -Force $destDir | Out-Null
+                Copy-Item $src $destDir -Force
+            }
+        }
+    }
 
     # prepare output dir
-    if (Test-Path $outputDir) { Remove-Item $outputDir -Recurse -Force }
-    New-Item -ItemType Directory $outputDir
-    New-Item -ItemType Directory "$outputDir/bin"
+    Reset-Dir $outputDir
+    New-Item -ItemType Directory -Force "$outputDir/bin" | Out-Null
 
     # copy to output
-    Copy-Item "$cliOut/*" "$outputDir/bin" -Recurse
+    Copy-Item "$cliOut/*" "$outputDir/bin" -Recurse -Force
     Copy-Item "$guiOut/*" "$outputDir/bin" -Recurse -Force
 
-    # move files out
+    # move launcher exes next to bin/
     foreach ($exe in 'AnimeStudio.GUI.exe', 'AnimeStudio.CLI.exe') {
-        Move-Item "$outputDir/bin/$exe" $outputDir
+        $from = "$outputDir/bin/$exe"
+        if (Test-Path $from) {
+            Move-Item $from $outputDir -Force
+        } else {
+            throw "Expected '$from' after copy"
+        }
     }
-    Move-Item "$outputDir/bin/LICENSE" $outputDir
+    if (Test-Path "$outputDir/bin/LICENSE") {
+        Move-Item "$outputDir/bin/LICENSE" $outputDir -Force
+    } elseif (Test-Path ".\LICENSE") {
+        Copy-Item ".\LICENSE" $outputDir -Force
+    }
+
+    # sanity: apphost must point at bin\<dll>, not bin\bin\...
+    foreach ($exe in 'AnimeStudio.GUI.exe', 'AnimeStudio.CLI.exe') {
+        $bytes = [System.IO.File]::ReadAllBytes((Resolve-Path "$outputDir/$exe"))
+        $text = [System.Text.Encoding]::UTF8.GetString($bytes)
+        if ($text -match 'bin\\bin\\') {
+            throw "$exe still embeds a stacked bin\\ path — patcher failed"
+        }
+        $dllName = [System.IO.Path]::ChangeExtension($exe, '.dll')
+        if ($text -notmatch [regex]::Escape("bin\$dllName")) {
+            Write-Warning "$exe may not embed expected path bin\$dllName"
+        }
+    }
+
+    Write-Host "Built $outputDir" -ForegroundColor Green
 }


### PR DESCRIPTION
- Fix abnormal memory use when building CAB/Asset maps for HSR 4.4 (fix #99).
- Stream map output and flush multi-ENCR `.block` bundles one at a time instead of retaining the whole game in RAM.
- Skip full `SerializedShader` parsing during map builds (HSR shaders can exceed 100MB).
- Fix AppHost patcher stacking `bin\` on every `build.ps1` run.