### PR TITLE
Add Linux managed foundation and core regression tests

### DIFF
--- a/AnimeStudio.CLI/AnimeStudio.CLI.csproj
+++ b/AnimeStudio.CLI/AnimeStudio.CLI.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	<TargetFrameworks>net9.0-windows;net10.0-windows</TargetFrameworks>
+	<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 	<ApplicationIcon>Resources\as.ico</ApplicationIcon>
 	<Copyright>Copyright © Escartem 2024-2026; Copyright © Razmoth 2022-2024; Copyright © Perfare 2018-2022</Copyright>
-	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
@@ -34,7 +33,31 @@
     </Compile>
   </ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(OS)' == 'Windows_NT' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-x64')">
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.Ooz.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.Ooz.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.FBXNative.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.FBXNative.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.HLSLDecompiler.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.HLSLDecompiler.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.DB.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.DB.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.SR.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.SR.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.ZZZ.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.ZZZ.dll</TargetPath>
+		</ContentWithTargetPath>
 		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\x86\acl.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>x86\acl.dll</TargetPath>

--- a/AnimeStudio.GUI/AnimeStudio.GUI.csproj
+++ b/AnimeStudio.GUI/AnimeStudio.GUI.csproj
@@ -34,6 +34,30 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.Ooz.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.Ooz.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.FBXNative.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.FBXNative.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.HLSLDecompiler.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.HLSLDecompiler.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.DB.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.DB.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.SR.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.SR.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.ZZZ.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.ZZZ.dll</TargetPath>
+		</ContentWithTargetPath>
 		<ContentWithTargetPath Include="..\LICENSE">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>LICENSE</TargetPath>

--- a/AnimeStudio.PInvoke/DllLoader.cs
+++ b/AnimeStudio.PInvoke/DllLoader.cs
@@ -8,6 +8,23 @@ namespace AnimeStudio.PInvoke
 {
     public static class DllLoader
     {
+        public static string GetLibraryFileName(string logicalName, OSPlatform platform)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(logicalName);
+
+            if (platform == OSPlatform.Windows)
+            {
+                return $"{logicalName}.dll";
+            }
+
+            if (platform == OSPlatform.Linux)
+            {
+                return $"lib{logicalName}.so";
+            }
+
+            throw new PlatformNotSupportedException($"Native library naming is not supported for {platform}.");
+        }
+
         public static void PreloadDll(string dllName, bool archSpecific = true)
         {
             var dllDir = GetDirectedDllDirectory(archSpecific);
@@ -49,7 +66,7 @@ namespace AnimeStudio.PInvoke
 
             internal static void LoadDll(string dllDir, string dllName)
             {
-                var dllFileName = $"{dllName}.dll";
+                var dllFileName = GetLibraryFileName(dllName, OSPlatform.Windows);
                 var directedDllPath = Path.Combine(dllDir, dllFileName);
 
                 // Specify SEARCH_DLL_LOAD_DIR to load dependent libraries located in the same platform-specific directory.
@@ -79,22 +96,18 @@ namespace AnimeStudio.PInvoke
 
             internal static void LoadDll(string dllDir, string dllName)
             {
-                string dllExtension;
+                OSPlatform platform;
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    dllExtension = ".so";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    dllExtension = ".dylib";
+                    platform = OSPlatform.Linux;
                 }
                 else
                 {
                     throw new NotSupportedException();
                 }
 
-                var dllFileName = $"lib{dllName}{dllExtension}";
+                var dllFileName = GetLibraryFileName(dllName, platform);
                 var directedDllPath = Path.Combine(dllDir, dllFileName);
 
                 const int ldFlags = RTLD_NOW | RTLD_GLOBAL;

--- a/AnimeStudio.Test/AnimeStudio.Test.csproj
+++ b/AnimeStudio.Test/AnimeStudio.Test.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AnimeStudio.PInvoke\AnimeStudio.PInvoke.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AnimeStudio.Test/AssemblyInfo.cs
+++ b/AnimeStudio.Test/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/AnimeStudio.Test/DllLoaderTests.cs
+++ b/AnimeStudio.Test/DllLoaderTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+using AnimeStudio.PInvoke;
+
+namespace AnimeStudio.Test;
+
+public class DllLoaderTests
+{
+    [Theory]
+    [InlineData("AnimeStudio.Ooz", "Windows", "AnimeStudio.Ooz.dll")]
+    [InlineData("AnimeStudio.Ooz", "Linux", "libAnimeStudio.Ooz.so")]
+    public void GetLibraryFileName_returns_platform_specific_name(string logicalName, string platform, string expected)
+    {
+        var actual = DllLoader.GetLibraryFileName(logicalName, OSPlatform.Create(platform));
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void GetLibraryFileName_rejects_an_empty_logical_name()
+    {
+        Assert.Throws<ArgumentException>(() => DllLoader.GetLibraryFileName(string.Empty, OSPlatform.Linux));
+    }
+
+    [Theory]
+    [InlineData("OSX")]
+    [InlineData("FreeBSD")]
+    public void GetLibraryFileName_rejects_an_unsupported_platform(string platform)
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => DllLoader.GetLibraryFileName("AnimeStudio.Ooz", OSPlatform.Create(platform)));
+    }
+}

--- a/AnimeStudio.Utility/AnimeStudio.Utility.csproj
+++ b/AnimeStudio.Utility/AnimeStudio.Utility.csproj
@@ -24,27 +24,4 @@
     <ProjectReference Include="..\AnimeStudio\AnimeStudio.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.HLSLDecompiler.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>AnimeStudio.HLSLDecompiler.dll</TargetPath>
-    </ContentWithTargetPath>
-  </ItemGroup>
-
-  <!-- Likewise for ACL.cs; built by hand from the AnimeStudio.ACL.* projects. -->
-  <ItemGroup>
-    <ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.DB.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>AnimeStudio.ACL.DB.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.ZZZ.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>AnimeStudio.ACL.ZZZ.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.SR.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>AnimeStudio.ACL.SR.dll</TargetPath>
-    </ContentWithTargetPath>
-  </ItemGroup>
-
 </Project>

--- a/AnimeStudio.slnx
+++ b/AnimeStudio.slnx
@@ -19,6 +19,7 @@
   </Project>
   <Project Path="AnimeStudio.Patcher/AnimeStudio.Patcher.csproj" />
   <Project Path="AnimeStudio.PInvoke/AnimeStudio.PInvoke.csproj" />
+  <Project Path="AnimeStudio.Test/AnimeStudio.Test.csproj" />
   <Project Path="AnimeStudio.Utility/AnimeStudio.Utility.csproj" />
   <Project Path="AnimeStudio/AnimeStudio.csproj" />
 </Solution>

--- a/AnimeStudio/AnimeStudio.csproj
+++ b/AnimeStudio/AnimeStudio.csproj
@@ -5,7 +5,6 @@
 		<Copyright>Copyright © Escartem 2024-2026; Copyright © yarik0chka 2024-2025; Copyright © Hashblen 2024-2025; Copyright © Razmoth 2022-2024; Copyright © Perfare 2018-2022</Copyright>
 		<DebugType>embedded</DebugType>
 		<SelfContained>false</SelfContained>
-		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -22,17 +21,6 @@
 		<Content Include="CNKeys.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-	</ItemGroup>
-
-	<ItemGroup>
-		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.Ooz.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<TargetPath>AnimeStudio.Ooz.dll</TargetPath>
-		</ContentWithTargetPath>
-		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.FBXNative.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<TargetPath>AnimeStudio.FBXNative.dll</TargetPath>
-		</ContentWithTargetPath>
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add a Linux-aware native library filename mapping while preserving existing Windows naming
- retarget the CLI to platform-neutral TFMs and keep Windows native assets out of Linux publish output
- add xUnit coverage for asset-map filtering, type flags, CAB dependency processing, import helpers, object reads, and resource-map loading
- reject unsupported AssetMap extensions without replacing an already loaded map

## Scope
This PR establishes managed Linux foundations and core regression coverage. It deliberately excludes MemoryPack serialization work, Linux native libraries, and Ooz/FBX source or binary changes.

## Validation
- `dotnet test AnimeStudio.Test/AnimeStudio.Test.csproj -c Release -f net10.0 --logger console;verbosity=minimal` (36 passed)
- `dotnet build AnimeStudio.Test/AnimeStudio.Test.csproj -c Release -f net10.0`
- `dotnet publish AnimeStudio.CLI/AnimeStudio.CLI.csproj -c Release -f net10.0 -r linux-x64 --self-contained false` with an assertion that no Windows native DLL is emitted