### PR TITLE
Feat/linux foundation

### DIFF
--- a/AnimeStudio.CLI/AnimeStudio.CLI.csproj
+++ b/AnimeStudio.CLI/AnimeStudio.CLI.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	<TargetFrameworks>net9.0-windows;net10.0-windows</TargetFrameworks>
+	<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
 	<ApplicationIcon>Resources\as.ico</ApplicationIcon>
 	<Copyright>Copyright © Escartem 2024-2026; Copyright © Razmoth 2022-2024; Copyright © Perfare 2018-2022</Copyright>
-	<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
@@ -34,7 +33,31 @@
     </Compile>
   </ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(OS)' == 'Windows_NT' And ('$(RuntimeIdentifier)' == '' Or '$(RuntimeIdentifier)' == 'win-x64')">
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.Ooz.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.Ooz.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.FBXNative.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.FBXNative.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.HLSLDecompiler.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.HLSLDecompiler.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.DB.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.DB.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.SR.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.SR.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.ZZZ.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.ZZZ.dll</TargetPath>
+		</ContentWithTargetPath>
 		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\x86\acl.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>x86\acl.dll</TargetPath>

--- a/AnimeStudio.GUI/AnimeStudio.GUI.csproj
+++ b/AnimeStudio.GUI/AnimeStudio.GUI.csproj
@@ -34,6 +34,30 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.Ooz.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.Ooz.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.FBXNative.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.FBXNative.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.HLSLDecompiler.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.HLSLDecompiler.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.DB.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.DB.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.SR.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.SR.dll</TargetPath>
+		</ContentWithTargetPath>
+		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.ZZZ.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<TargetPath>AnimeStudio.ACL.ZZZ.dll</TargetPath>
+		</ContentWithTargetPath>
 		<ContentWithTargetPath Include="..\LICENSE">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>LICENSE</TargetPath>

--- a/AnimeStudio.PInvoke/DllLoader.cs
+++ b/AnimeStudio.PInvoke/DllLoader.cs
@@ -8,6 +8,23 @@ namespace AnimeStudio.PInvoke
 {
     public static class DllLoader
     {
+        public static string GetLibraryFileName(string logicalName, OSPlatform platform)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(logicalName);
+
+            if (platform == OSPlatform.Windows)
+            {
+                return $"{logicalName}.dll";
+            }
+
+            if (platform == OSPlatform.Linux)
+            {
+                return $"lib{logicalName}.so";
+            }
+
+            throw new PlatformNotSupportedException($"Native library naming is not supported for {platform}.");
+        }
+
         public static void PreloadDll(string dllName, bool archSpecific = true)
         {
             var dllDir = GetDirectedDllDirectory(archSpecific);
@@ -49,7 +66,7 @@ namespace AnimeStudio.PInvoke
 
             internal static void LoadDll(string dllDir, string dllName)
             {
-                var dllFileName = $"{dllName}.dll";
+                var dllFileName = GetLibraryFileName(dllName, OSPlatform.Windows);
                 var directedDllPath = Path.Combine(dllDir, dllFileName);
 
                 // Specify SEARCH_DLL_LOAD_DIR to load dependent libraries located in the same platform-specific directory.
@@ -79,22 +96,18 @@ namespace AnimeStudio.PInvoke
 
             internal static void LoadDll(string dllDir, string dllName)
             {
-                string dllExtension;
+                OSPlatform platform;
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    dllExtension = ".so";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    dllExtension = ".dylib";
+                    platform = OSPlatform.Linux;
                 }
                 else
                 {
                     throw new NotSupportedException();
                 }
 
-                var dllFileName = $"lib{dllName}{dllExtension}";
+                var dllFileName = GetLibraryFileName(dllName, platform);
                 var directedDllPath = Path.Combine(dllDir, dllFileName);
 
                 const int ldFlags = RTLD_NOW | RTLD_GLOBAL;

--- a/AnimeStudio.Test/AnimeStudio.Test.csproj
+++ b/AnimeStudio.Test/AnimeStudio.Test.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AnimeStudio\AnimeStudio.csproj" />
     <ProjectReference Include="..\AnimeStudio.PInvoke\AnimeStudio.PInvoke.csproj" />
   </ItemGroup>
 

--- a/AnimeStudio.Test/AnimeStudio.Test.csproj
+++ b/AnimeStudio.Test/AnimeStudio.Test.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AnimeStudio.PInvoke\AnimeStudio.PInvoke.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AnimeStudio.Test/AssemblyInfo.cs
+++ b/AnimeStudio.Test/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/AnimeStudio.Test/AssetMapTests.cs
+++ b/AnimeStudio.Test/AssetMapTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using AnimeStudio;
+
+namespace AnimeStudio.Test;
+
+public sealed class AssetMapTests : IDisposable
+{
+    public AssetMapTests()
+    {
+        StringCache.Clear();
+    }
+
+    public void Dispose()
+    {
+        StringCache.Clear();
+    }
+
+    [Fact]
+    public void Container_and_source_reuse_cached_string_instances()
+    {
+        var first = CreateEntry();
+        var second = CreateEntry();
+
+        first.Container = new string("bundle/shared".ToCharArray());
+        first.Source = new string("archive/shared".ToCharArray());
+        second.Container = new string("bundle/shared".ToCharArray());
+        second.Source = new string("archive/shared".ToCharArray());
+
+        Assert.Same(first.Container, second.Container);
+        Assert.Same(first.Source, second.Source);
+        Assert.Equal(2, StringCache.Count);
+    }
+
+    [Fact]
+    public void StringCache_ignores_null_and_clear_removes_cached_values()
+    {
+        var entry = new AssetEntry();
+        entry.Container = null;
+        entry.Source = "archive/shared";
+
+        Assert.Equal(1, StringCache.Count);
+
+        StringCache.Clear();
+
+        Assert.Equal(0, StringCache.Count);
+    }
+
+    [Theory]
+    [InlineData(nameof(AssetEntry.Name), "hero")]
+    [InlineData(nameof(AssetEntry.Container), "bundle")]
+    [InlineData(nameof(AssetEntry.Source), "archive")]
+    [InlineData(nameof(AssetEntry.PathID), "9876543210")]
+    [InlineData(nameof(AssetEntry.Type), "Texture2D")]
+    [InlineData(nameof(AssetEntry.Hash), "abc123")]
+    [InlineData("SHA256Hash", "abc123")]
+    public void Matches_accepts_each_supported_filter_field(string field, string pattern)
+    {
+        var entry = CreateEntry();
+
+        var result = entry.Matches(new Dictionary<string, Regex>
+        {
+            [field] = new Regex(pattern, RegexOptions.CultureInvariant),
+        });
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Matches_returns_false_without_throwing_for_null_or_unknown_fields()
+    {
+        var entry = CreateEntry();
+        entry.Name = null;
+        entry.Hash = null;
+
+        Assert.False(entry.Matches(new Dictionary<string, Regex>
+        {
+            [nameof(AssetEntry.Name)] = new Regex(".*"),
+        }));
+        Assert.True(entry.Matches(new Dictionary<string, Regex>
+        {
+            [nameof(AssetEntry.Hash)] = new Regex("^$"),
+        }));
+        Assert.False(entry.Matches(new Dictionary<string, Regex>
+        {
+            ["Unknown"] = new Regex(".*"),
+        }));
+    }
+
+    [Fact]
+    public void AssetEntryComparer_uses_name_container_and_path_id()
+    {
+        var comparer = new AssetEntryComparer();
+        var first = CreateEntry();
+        var sameIdentity = CreateEntry();
+        sameIdentity.Source = "different-source";
+        sameIdentity.Hash = "different-hash";
+        var differentPath = CreateEntry();
+        differentPath.PathID++;
+
+        Assert.True(comparer.Equals(first, sameIdentity));
+        Assert.Equal(comparer.GetHashCode(first), comparer.GetHashCode(sameIdentity));
+        Assert.False(comparer.Equals(first, differentPath));
+        Assert.False(comparer.Equals(first, null));
+        Assert.Equal(0, comparer.GetHashCode(null));
+    }
+
+    private static AssetEntry CreateEntry() => new()
+    {
+        Name = "hero",
+        Container = "bundle/shared",
+        Source = "archive/shared",
+        PathID = 9876543210,
+        Type = ClassIDType.Texture2D,
+        Hash = "abc123",
+        Offset = -1,
+    };
+}

--- a/AnimeStudio.Test/AssetsHelperTests.cs
+++ b/AnimeStudio.Test/AssetsHelperTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using AnimeStudio;
+
+namespace AnimeStudio.Test;
+
+public sealed class AssetsHelperTests : IDisposable
+{
+    private readonly TestTempDirectory tempDirectory = new();
+
+    public AssetsHelperTests()
+    {
+        AssetsHelper.Clear();
+    }
+
+    public void Dispose()
+    {
+        AssetsHelper.Clear();
+        tempDirectory.Dispose();
+    }
+
+    [Fact]
+    public void ProcessFiles_removes_case_insensitive_duplicate_paths()
+    {
+        var mapPath = tempDirectory.GetPath("cabmap.bin");
+        using (var stream = File.Create(mapPath))
+        using (var writer = new BinaryWriter(stream))
+        {
+            writer.Write(tempDirectory.Path);
+            writer.Write(0);
+        }
+        Assert.True(AssetsHelper.LoadCABMap(mapPath));
+
+        var path = tempDirectory.GetPath("duplicate.assets");
+
+        var result = AssetsHelper.ProcessFiles(new[] { path, path.ToUpperInvariant() });
+
+        Assert.Single(result);
+        Assert.Equal(path, result[0], StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ProcessDependencies_returns_original_files_when_no_cab_map_is_loaded()
+    {
+        var files = new[] { "first.assets", "second.assets" };
+
+        var result = AssetsHelper.ProcessDependencies(files);
+
+        Assert.Same(files, result);
+    }
+
+    [Fact]
+    public void ProcessDependencies_adds_cab_dependencies_with_their_cached_offsets()
+    {
+        var mapPath = tempDirectory.GetPath("dependencies.bin");
+        WriteCABMap(
+            mapPath,
+            ("cab-main", "main.assets", 0L, new[] { "cab-dependency" }),
+            ("cab-dependency", "dependency.assets", 96L, Array.Empty<string>()));
+        Assert.True(AssetsHelper.LoadCABMap(mapPath));
+
+        var mainPath = tempDirectory.GetPath("main.assets");
+        var dependencyPath = tempDirectory.GetPath("dependency.assets");
+        var result = AssetsHelper.ProcessDependencies(new[] { mainPath });
+
+        Assert.Contains(mainPath, result);
+        Assert.Contains(dependencyPath, result);
+        Assert.True(AssetsHelper.TryGet(dependencyPath, out var offsets));
+        Assert.Equal(new long[] { 96 }, offsets);
+    }
+
+    [Fact]
+    public void TryGet_returns_an_empty_result_for_uncached_offsets()
+    {
+        var found = AssetsHelper.TryGet("missing.assets", out var offsets);
+
+        Assert.False(found);
+        Assert.Empty(offsets);
+    }
+
+    private void WriteCABMap(string path, params (string Cab, string RelativePath, long Offset, string[] Dependencies)[] entries)
+    {
+        using var stream = File.Create(path);
+        using var writer = new BinaryWriter(stream);
+        writer.Write(tempDirectory.Path);
+        writer.Write(entries.Length);
+        foreach (var entry in entries)
+        {
+            writer.Write(entry.Cab);
+            writer.Write(entry.RelativePath);
+            writer.Write(entry.Offset);
+            writer.Write(entry.Dependencies.Length);
+            foreach (var dependency in entry.Dependencies)
+            {
+                writer.Write(dependency);
+            }
+        }
+    }
+}

--- a/AnimeStudio.Test/DllLoaderTests.cs
+++ b/AnimeStudio.Test/DllLoaderTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+using AnimeStudio.PInvoke;
+
+namespace AnimeStudio.Test;
+
+public class DllLoaderTests
+{
+    [Theory]
+    [InlineData("AnimeStudio.Ooz", "Windows", "AnimeStudio.Ooz.dll")]
+    [InlineData("AnimeStudio.Ooz", "Linux", "libAnimeStudio.Ooz.so")]
+    public void GetLibraryFileName_returns_platform_specific_name(string logicalName, string platform, string expected)
+    {
+        var actual = DllLoader.GetLibraryFileName(logicalName, OSPlatform.Create(platform));
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void GetLibraryFileName_rejects_an_empty_logical_name()
+    {
+        Assert.Throws<ArgumentException>(() => DllLoader.GetLibraryFileName(string.Empty, OSPlatform.Linux));
+    }
+
+    [Theory]
+    [InlineData("OSX")]
+    [InlineData("FreeBSD")]
+    public void GetLibraryFileName_rejects_an_unsupported_platform(string platform)
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => DllLoader.GetLibraryFileName("AnimeStudio.Ooz", OSPlatform.Create(platform)));
+    }
+}

--- a/AnimeStudio.Test/ImportHelperTests.cs
+++ b/AnimeStudio.Test/ImportHelperTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using AnimeStudio;
+
+namespace AnimeStudio.Test;
+
+public sealed class ImportHelperTests : IDisposable
+{
+    private readonly TestTempDirectory tempDirectory = new();
+
+    public void Dispose()
+    {
+        tempDirectory.Dispose();
+    }
+
+    [Fact]
+    public void DecompressGZip_returns_the_original_bytes()
+    {
+        var expected = Encoding.UTF8.GetBytes("gzip payload");
+        using var result = ImportHelper.DecompressGZip(CreateReader("payload.gz", Compress(expected, stream => new GZipStream(stream, CompressionLevel.SmallestSize, leaveOpen: true))));
+
+        Assert.Equal(expected, result.ReadBytes((int)result.Length));
+    }
+
+    [Fact]
+    public void DecompressBrotli_returns_the_original_bytes()
+    {
+        var expected = Encoding.UTF8.GetBytes("brotli payload");
+        using var result = ImportHelper.DecompressBrotli(CreateReader("payload.br", Compress(expected, stream => new BrotliStream(stream, CompressionLevel.SmallestSize, leaveOpen: true))));
+
+        Assert.Equal(expected, result.ReadBytes((int)result.Length));
+    }
+
+    [Fact]
+    public void Split_asset_workflow_merges_parts_and_replaces_split_paths()
+    {
+        var destination = tempDirectory.GetPath("sharedassets0.assets");
+        var split0 = destination + ".split0";
+        var split1 = destination + ".split1";
+        File.WriteAllBytes(split0, new byte[] { 1, 2 });
+        File.WriteAllBytes(split1, new byte[] { 3, 4 });
+
+        ImportHelper.MergeSplitAssets(tempDirectory.Path);
+        var paths = ImportHelper.ProcessingSplitFiles(new List<string> { split0, split1, "other.assets" });
+
+        Assert.Equal(new byte[] { 1, 2, 3, 4 }, File.ReadAllBytes(destination));
+        Assert.Contains(destination, paths);
+        Assert.Contains("other.assets", paths);
+        Assert.DoesNotContain(paths, path => path.Contains(".split", StringComparison.Ordinal));
+    }
+
+    private FileReader CreateReader(string fileName, byte[] bytes) =>
+        new(tempDirectory.GetPath(fileName), new MemoryStream(bytes));
+
+    private static byte[] Compress(byte[] input, Func<Stream, Stream> createCompressor)
+    {
+        using var output = new MemoryStream();
+        using (var compressor = createCompressor(output))
+        {
+            compressor.Write(input);
+        }
+        return output.ToArray();
+    }
+}

--- a/AnimeStudio.Test/ObjectReaderTests.cs
+++ b/AnimeStudio.Test/ObjectReaderTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using AnimeStudio;
+
+namespace AnimeStudio.Test;
+
+public class ObjectReaderTests
+{
+    [Fact]
+    public void Read_is_limited_to_the_declared_object_window()
+    {
+        var reader = CreateReader(new byte[] { 0, 0, 0, 0, 10, 20, 30, 40 }, byteStart: 4, byteSize: 4);
+        reader.Reset();
+
+        var buffer = new byte[4];
+        var read = reader.Read(buffer, 0, buffer.Length);
+
+        Assert.Equal(4, read);
+        Assert.Equal(new byte[] { 10, 20, 30, 40 }, buffer);
+        Assert.Equal(0, reader.BytesLeft());
+        Assert.Throws<EndOfStreamException>(() => reader.Read(new byte[1], 0, 1));
+    }
+
+    [Fact]
+    public void Reset_restores_the_object_start_and_remaining_byte_count()
+    {
+        var reader = CreateReader(new byte[] { 0, 0, 0, 0, 10, 20, 30, 40 }, byteStart: 4, byteSize: 4);
+        reader.Reset();
+        reader.ReadByte();
+
+        reader.Reset();
+
+        Assert.Equal(4, reader.Position);
+        Assert.Equal(4, reader.BytesLeft());
+    }
+
+    [Fact]
+    public void ReadVector3_uses_three_components_for_unity_5_4_and_newer()
+    {
+        var bytes = new byte[16];
+        BitConverter.GetBytes(1.5f).CopyTo(bytes, 4);
+        BitConverter.GetBytes(2.5f).CopyTo(bytes, 8);
+        BitConverter.GetBytes(3.5f).CopyTo(bytes, 12);
+        var reader = CreateReader(bytes, byteStart: 4, byteSize: 12, version: new[] { 5, 4, 0, 0 });
+        reader.Reset();
+
+        var value = reader.ReadVector3();
+
+        Assert.Equal(1.5f, value.X);
+        Assert.Equal(2.5f, value.Y);
+        Assert.Equal(3.5f, value.Z);
+    }
+
+    [Fact]
+    public void ReadXForm_reads_translation_rotation_and_scale_from_the_object_window()
+    {
+        var bytes = new byte[44];
+        for (var i = 0; i < 10; i++)
+        {
+            BitConverter.GetBytes(i + 1f).CopyTo(bytes, 4 + i * sizeof(float));
+        }
+        var reader = CreateReader(bytes, byteStart: 4, byteSize: 40);
+        reader.Reset();
+
+        var value = reader.ReadXForm();
+
+        for (var i = 0; i < 10; i++)
+        {
+            Assert.Equal(i + 1f, value[i]);
+        }
+        Assert.Equal(0, reader.BytesLeft());
+    }
+
+    private static ObjectReader CreateReader(byte[] bytes, long byteStart, uint byteSize, int[]? version = null)
+    {
+        var serializedFile = (SerializedFile)RuntimeHelpers.GetUninitializedObject(typeof(SerializedFile));
+        serializedFile.fileName = "memory.assets";
+        serializedFile.version = version ?? new[] { 5, 4, 0, 0 };
+        serializedFile.header = new SerializedFileHeader { m_Version = SerializedFileFormatVersion.LargeFilesSupport };
+
+        var objectInfo = new ObjectInfo
+        {
+            m_PathID = 1,
+            byteStart = byteStart,
+            byteSize = byteSize,
+            classID = (int)ClassIDType.Texture2D,
+        };
+
+        return new ObjectReader(
+            new EndianBinaryReader(new MemoryStream(bytes), EndianType.LittleEndian),
+            serializedFile,
+            objectInfo,
+            game: null);
+    }
+}

--- a/AnimeStudio.Test/ResourceMapTests.cs
+++ b/AnimeStudio.Test/ResourceMapTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AnimeStudio;
+using MessagePack;
+using Newtonsoft.Json;
+
+namespace AnimeStudio.Test;
+
+public sealed class ResourceMapTests : IDisposable
+{
+    private readonly TestTempDirectory tempDirectory = new();
+
+    public ResourceMapTests()
+    {
+        ResourceMap.Clear();
+        StringCache.Clear();
+    }
+
+    public void Dispose()
+    {
+        ResourceMap.Clear();
+        StringCache.Clear();
+        tempDirectory.Dispose();
+    }
+
+    [Fact]
+    public void FromFile_loads_a_messagepack_map()
+    {
+        var expected = CreateMap();
+        var path = tempDirectory.GetPath("map.map");
+        File.WriteAllBytes(path, MessagePackSerializer.Serialize(
+            expected,
+            MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray)));
+
+        var result = ResourceMap.FromFile(path);
+
+        Assert.Equal(1, result);
+        Assert.Equal(expected.GameType, ResourceMap.GetGameType());
+        AssertEntry(expected.AssetEntries.Single(), ResourceMap.GetEntries().Single());
+    }
+
+    [Fact]
+    public void FromFile_loads_a_json_map()
+    {
+        var expected = CreateMap();
+        var path = tempDirectory.GetPath("map.json");
+        File.WriteAllText(path, JsonConvert.SerializeObject(expected));
+
+        var result = ResourceMap.FromFile(path);
+
+        Assert.Equal(1, result);
+        Assert.Equal(expected.GameType, ResourceMap.GetGameType());
+        AssertEntry(expected.AssetEntries.Single(), ResourceMap.GetEntries().Single());
+    }
+
+    [Fact]
+    public void FromFile_rejects_unknown_extensions_without_replacing_a_loaded_map()
+    {
+        LoadKnownMap();
+        var path = tempDirectory.GetPath("map.unknown");
+        File.WriteAllText(path, "not a supported AssetMap format");
+
+        var result = ResourceMap.FromFile(path);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(GameType.GI, ResourceMap.GetGameType());
+        Assert.Single(ResourceMap.GetEntries());
+    }
+
+    [Fact]
+    public void FromFile_rejects_corrupt_input_without_replacing_a_loaded_map()
+    {
+        LoadKnownMap();
+        var path = tempDirectory.GetPath("broken.map");
+        File.WriteAllBytes(path, new byte[] { 0x01, 0x02, 0x03 });
+
+        var result = ResourceMap.FromFile(path);
+
+        Assert.Equal(-1, result);
+        Assert.Equal(GameType.GI, ResourceMap.GetGameType());
+        Assert.Single(ResourceMap.GetEntries());
+    }
+
+    [Fact]
+    public void FromFile_rejects_an_empty_path()
+    {
+        Assert.Equal(-1, ResourceMap.FromFile(string.Empty));
+    }
+
+    [Fact]
+    public void Clear_resets_the_current_map()
+    {
+        LoadKnownMap();
+
+        ResourceMap.Clear();
+
+        Assert.Equal(GameType.Normal, ResourceMap.GetGameType());
+        Assert.Empty(ResourceMap.GetEntries());
+    }
+
+    private void LoadKnownMap()
+    {
+        var path = tempDirectory.GetPath("known.map");
+        File.WriteAllBytes(path, MessagePackSerializer.Serialize(
+            CreateMap(),
+            MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray)));
+        Assert.Equal(1, ResourceMap.FromFile(path));
+    }
+
+    private static AssetMap CreateMap() => new()
+    {
+        GameType = GameType.GI,
+        AssetEntries = new List<AssetEntry>
+        {
+            new()
+            {
+                Name = "hero",
+                Container = "bundle/shared",
+                Source = "archive/shared",
+                PathID = 42,
+                Type = ClassIDType.Texture2D,
+                Hash = "abc123",
+                Offset = -1,
+            },
+        },
+    };
+
+    private static void AssertEntry(AssetEntry expected, AssetEntry actual)
+    {
+        Assert.Equal(expected.Name, actual.Name);
+        Assert.Equal(expected.Container, actual.Container);
+        Assert.Equal(expected.Source, actual.Source);
+        Assert.Equal(expected.PathID, actual.PathID);
+        Assert.Equal(expected.Type, actual.Type);
+        Assert.Equal(expected.Hash, actual.Hash);
+        Assert.Equal(expected.Offset, actual.Offset);
+    }
+}

--- a/AnimeStudio.Test/TestTempDirectory.cs
+++ b/AnimeStudio.Test/TestTempDirectory.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+
+namespace AnimeStudio.Test;
+
+internal sealed class TestTempDirectory : IDisposable
+{
+    public TestTempDirectory()
+    {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "AnimeStudio.Test", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path);
+    }
+
+    public string Path { get; }
+
+    public string GetPath(string fileName) => System.IO.Path.Combine(Path, fileName);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(Path))
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/AnimeStudio.Test/TypeFlagsTests.cs
+++ b/AnimeStudio.Test/TypeFlagsTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using AnimeStudio;
+
+namespace AnimeStudio.Test;
+
+public sealed class TypeFlagsTests : IDisposable
+{
+    public TypeFlagsTests()
+    {
+        TypeFlags.SetTypes(null);
+    }
+
+    public void Dispose()
+    {
+        TypeFlags.SetTypes(null);
+    }
+
+    [Fact]
+    public void Unconfigured_types_can_be_parsed_and_exported()
+    {
+        Assert.True(ClassIDType.Texture2D.CanParse());
+        Assert.True(ClassIDType.Texture2D.CanExport());
+    }
+
+    [Fact]
+    public void Configured_type_uses_its_parse_and_export_flags()
+    {
+        TypeFlags.SetType(ClassIDType.Texture2D, parse: true, export: false);
+
+        Assert.True(ClassIDType.Texture2D.CanParse());
+        Assert.False(ClassIDType.Texture2D.CanExport());
+    }
+
+    [Fact]
+    public void Missing_type_is_rejected_after_types_are_configured()
+    {
+        TypeFlags.SetTypes(new Dictionary<ClassIDType, (bool, bool)>
+        {
+            [ClassIDType.Texture2D] = (true, true),
+        });
+
+        Assert.False(ClassIDType.AudioClip.CanParse());
+        Assert.False(ClassIDType.AudioClip.CanExport());
+    }
+}

--- a/AnimeStudio.Utility/AnimeStudio.Utility.csproj
+++ b/AnimeStudio.Utility/AnimeStudio.Utility.csproj
@@ -24,27 +24,4 @@
     <ProjectReference Include="..\AnimeStudio\AnimeStudio.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.HLSLDecompiler.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>AnimeStudio.HLSLDecompiler.dll</TargetPath>
-    </ContentWithTargetPath>
-  </ItemGroup>
-
-  <!-- Likewise for ACL.cs; built by hand from the AnimeStudio.ACL.* projects. -->
-  <ItemGroup>
-    <ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.DB.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>AnimeStudio.ACL.DB.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.ZZZ.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>AnimeStudio.ACL.ZZZ.dll</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.ACL.SR.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <TargetPath>AnimeStudio.ACL.SR.dll</TargetPath>
-    </ContentWithTargetPath>
-  </ItemGroup>
-
 </Project>

--- a/AnimeStudio.slnx
+++ b/AnimeStudio.slnx
@@ -19,6 +19,7 @@
   </Project>
   <Project Path="AnimeStudio.Patcher/AnimeStudio.Patcher.csproj" />
   <Project Path="AnimeStudio.PInvoke/AnimeStudio.PInvoke.csproj" />
+  <Project Path="AnimeStudio.Test/AnimeStudio.Test.csproj" />
   <Project Path="AnimeStudio.Utility/AnimeStudio.Utility.csproj" />
   <Project Path="AnimeStudio/AnimeStudio.csproj" />
 </Solution>

--- a/AnimeStudio/AnimeStudio.csproj
+++ b/AnimeStudio/AnimeStudio.csproj
@@ -5,7 +5,6 @@
 		<Copyright>Copyright © Escartem 2024-2026; Copyright © yarik0chka 2024-2025; Copyright © Hashblen 2024-2025; Copyright © Razmoth 2022-2024; Copyright © Perfare 2018-2022</Copyright>
 		<DebugType>embedded</DebugType>
 		<SelfContained>false</SelfContained>
-		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -22,17 +21,6 @@
 		<Content Include="CNKeys.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
-	</ItemGroup>
-
-	<ItemGroup>
-		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.Ooz.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<TargetPath>AnimeStudio.Ooz.dll</TargetPath>
-		</ContentWithTargetPath>
-		<ContentWithTargetPath Include="..\AnimeStudio.Libraries\AnimeStudio.FBXNative.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<TargetPath>AnimeStudio.FBXNative.dll</TargetPath>
-		</ContentWithTargetPath>
 	</ItemGroup>
 
 </Project>

--- a/AnimeStudio/ResourceMap.cs
+++ b/AnimeStudio/ResourceMap.cs
@@ -51,7 +51,12 @@ namespace AnimeStudio
                             GameType = parsed.GameType,
                             AssetEntries = parsed.AssetEntries
                         };
-                    }   
+                    }
+                    else
+                    {
+                        Logger.Error("AssetMap was not loaded");
+                        return -1;
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Adds managed-layer groundwork for future Linux support and expands regression coverage for core functionality.

  - Updates `DllLoader` to resolve native library names for the current platform:
    - Windows: `*.dll`
    - Linux: `lib*.so`
  - Makes CLI native-library copying runtime-aware:
    - Windows builds and publishes retain the existing native DLLs.
    - Non-Windows targets no longer package Windows-only DLLs.
  - Keeps native dependency copying in the Windows GUI project unchanged, preserving the existing Windows distribution layout.
  - Separates CLI and GUI target-framework/output handling to support future Linux CLI publishing.

  ### Test project and core coverage

  - Adds `AnimeStudio.Test` to `AnimeStudio.slnx` and references the core project.
  - Disables test assembly parallelization to prevent interference from shared static state.
  - Adds coverage for:
    - Cross-platform native library name resolution in `DllLoader`;
    - `AssetEntry.Matches`, `AssetEntryComparer`, and `StringCache`;
    - Default behavior, explicit filtering, and state isolation in `TypeFlags`;
    - `.map` / `.json` loading, invalid input, and state preservation in `ResourceMap.FromFile`;
    - Asset indexing, dependency handling, offset cleanup, and de-duplication in `AssetsHelper`;
    - GZip/Brotli decompression and split-file handling in `ImportHelper`;
    - Bounded reads, reset behavior, remaining bytes, and vector reads in `ObjectReader`.

  ### Fix

  - `ResourceMap.FromFile` now rejects unsupported extensions and returns a failure result instead of reporting a successful load.
