### PR TITLE
Fix SR ACL input buffer alignment

### DIFF
--- a/AnimeStudio.Utility/ACL/ACL.cs
+++ b/AnimeStudio.Utility/ACL/ACL.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using AnimeStudio.PInvoke;
 
@@ -53,23 +54,47 @@ namespace ACLLibs
         }
         public static void DecompressAll(byte[] data, out float[] values, out float[] times)
         {
+            ArgumentNullException.ThrowIfNull(data);
+            if (data.Length == 0)
+            {
+                throw new InvalidDataException("SR ACL clip data is empty.");
+            }
+
             var decompressedClip = new DecompressedClip();
-            DecompressClip(data, ref decompressedClip);
+            var dataPtr = Marshal.AllocHGlobal(data.Length + 15);
+            var dataAligned = new IntPtr(((long)dataPtr + 15L) & ~15L);
 
-            values = new float[decompressedClip.ValuesCount];
-            Marshal.Copy(decompressedClip.Values, values, 0, decompressedClip.ValuesCount);
+            try
+            {
+                Marshal.Copy(data, 0, dataAligned, data.Length);
+                DecompressClip(dataAligned, ref decompressedClip);
 
-            times = new float[decompressedClip.TimesCount];
-            Marshal.Copy(decompressedClip.Times, times, 0, decompressedClip.TimesCount);
+                if (decompressedClip.ValuesCount <= 0 || decompressedClip.TimesCount <= 0 ||
+                    decompressedClip.Values == IntPtr.Zero || decompressedClip.Times == IntPtr.Zero)
+                {
+                    throw new InvalidDataException(
+                        $"SR ACL decompression returned invalid output " +
+                        $"(values: {decompressedClip.ValuesCount}, times: {decompressedClip.TimesCount}).");
+                }
 
-            Dispose(ref decompressedClip);
+                values = new float[decompressedClip.ValuesCount];
+                Marshal.Copy(decompressedClip.Values, values, 0, decompressedClip.ValuesCount);
+
+                times = new float[decompressedClip.TimesCount];
+                Marshal.Copy(decompressedClip.Times, times, 0, decompressedClip.TimesCount);
+            }
+            finally
+            {
+                Dispose(ref decompressedClip);
+                Marshal.FreeHGlobal(dataPtr);
+            }
         }
 
         #region importfunctions
 
         // This one is the acl 1.x uniformly-sampled decoder; its export is named DecompressClip.
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        private static extern void DecompressClip(byte[] data, ref DecompressedClip decompressedClip);
+        private static extern void DecompressClip(nint data, ref DecompressedClip decompressedClip);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         private static extern void Dispose(ref DecompressedClip decompressedClip);

--- a/docs/sr-acl-buffer-alignment.md
+++ b/docs/sr-acl-buffer-alignment.md
@@ -1,0 +1,79 @@
+# SR ACL input buffer alignment
+
+## Summary
+
+Some `AnimationClip` assets failed during converted export with an exception from
+`Marshal.Copy`:
+
+```text
+Value cannot be null. (Parameter 'source')
+at ACLLibs.SRACL.DecompressAll(...)
+```
+
+The affected clips were valid. The failure was caused by passing a managed
+`byte[]` directly to the native SR ACL decoder even though the compressed clip
+input must be 16-byte aligned.
+
+## Root cause
+
+`SRACL.DecompressAll` previously declared the native entry point like this:
+
+```csharp
+private static extern void DecompressClip(byte[] data, ref DecompressedClip decompressedClip);
+```
+
+P/Invoke pins the managed array for the call, but it does not guarantee that the
+array starts at a 16-byte-aligned address. Consequently, decoding depended on the
+address selected by the managed allocator:
+
+- aligned arrays decoded normally;
+- unaligned arrays were rejected by the native ACL decoder;
+- the native wrapper returned without populating `Values` and `Times`;
+- `Marshal.Copy` then received `IntPtr.Zero` and reported a null `source`.
+
+This also explains why the GUI's final message could be misleading. Export
+exceptions and existing output files are both included in the generic
+`not extractable or files already exist` skipped count.
+
+## Fix
+
+The SR wrapper now:
+
+1. Allocates an unmanaged buffer with 15 bytes of alignment padding.
+2. Rounds its address up to the next 16-byte boundary.
+3. Copies the compressed clip into the aligned buffer.
+4. Passes the aligned pointer to the native decoder.
+5. Validates native output before calling `Marshal.Copy`.
+6. Releases both native decoder output and the temporary input buffer in a
+   `finally` block.
+
+The native import therefore accepts `nint` instead of a managed `byte[]`.
+
+## Verification
+
+The issue was reproduced with 39 `AnimationClip` assets from one block using the
+CLI converted-export path.
+
+| Build | Exported | Failed |
+| --- | ---: | ---: |
+| Baseline | 17 | 22 |
+| Aligned input | 39 | 0 |
+
+Both runs used the same input block, game selection, asset filter, export mode,
+and native decoder. The only behavioral change was alignment and validation in
+`SRACL.DecompressAll`.
+
+Representative command:
+
+```powershell
+AnimeStudio.CLI.exe SAMPLE.block OUTPUT_DIR `
+  --game SR `
+  --types AnimationClip:Both `
+  --names '^CLIP_NAME_PREFIX' `
+  --export_type Convert `
+  --group_assets None
+```
+
+Excluding the complete block is not an appropriate workaround: the block can
+contain both previously successful and previously failing clips, and all tested
+clips exported after aligning the decoder input.


### PR DESCRIPTION
## What changed

- copy SR ACL compressed clip data into a 16-byte-aligned unmanaged buffer before native decoding
- change the native import from managed `byte[]` marshalling to an explicit `nint`
- validate native output before `Marshal.Copy`
- release decoder output and the temporary input buffer from a `finally` block
- document the symptom, root cause, fix, and verification results

## Root cause

The SR ACL native decoder requires aligned compressed clip input. P/Invoke pinned
the previous managed `byte[]`, but the managed allocator did not guarantee a
16-byte-aligned start address. When an array was unaligned, the native decoder
returned without populating its output pointers, and the following
`Marshal.Copy` raised `Value cannot be null. (Parameter 'source')`.

## Impact

Converted export no longer depends on the managed array address. Valid clips
that previously appeared in the generic `not extractable or files already
exist` skipped count now export normally. Invalid native output also produces a
specific `InvalidDataException` instead of a misleading null-source exception.

## Validation

- `git diff --cached --check`: passed
- compatibility build with .NET SDK 9.0.202: 0 errors, 16 existing warnings
- same block and same 39-clip filter:
  - baseline: 17 exported, 22 failed
  - this branch: 39 exported, 0 errors
- previously failing single-clip regression: 1 exported, 0 errors

The repository project files were restored byte-for-byte after the temporary
net9 compatibility build; the PR changes only the SR ACL wrapper and its
documentation.
