### PR TITLE
Fix UnityCNEdit Form and UnityCN game selection

### DIFF
--- a/AnimeStudio.GUI/GameSelector.cs
+++ b/AnimeStudio.GUI/GameSelector.cs
@@ -84,7 +84,7 @@ namespace AnimeStudio.GUI
                     if (selectedGame.Type == GameType.UnityCNCustomKey)
                     {
                         customKeyText.Enabled = true;
-                        customKeyText.Text = "";
+                        customKeyText.Text = Properties.Settings.Default.lastUnityCNKey;
                     }
                     break;
             }
@@ -106,8 +106,7 @@ namespace AnimeStudio.GUI
                     Properties.Settings.Default.Save();
                 }
             }
-            Game game = GameManager.GetGameByDisplayName(selectedGame.DisplayName);
-            _parent.updateGame(game);
+            _parent.updateGame(selectedGame);
             this.Close();
         }
     }

--- a/AnimeStudio.GUI/GameSelector.cs
+++ b/AnimeStudio.GUI/GameSelector.cs
@@ -106,7 +106,8 @@ namespace AnimeStudio.GUI
                     Properties.Settings.Default.Save();
                 }
             }
-            _parent.updateGame(selectedGame.Type);
+            Game game = GameManager.GetGameByDisplayName(selectedGame.DisplayName);
+            _parent.updateGame(game);
             this.Close();
         }
     }

--- a/AnimeStudio.GUI/MainForm.cs
+++ b/AnimeStudio.GUI/MainForm.cs
@@ -2347,6 +2347,22 @@ namespace AnimeStudio.GUI
             Properties.Settings.Default.Save();
         }
 
+        public void updateGame(Game game)
+        {
+            int index = GameManager.GetGameIndex(game);
+            Properties.Settings.Default.selectedGame = index;
+            Properties.Settings.Default.Save();
+            ResetForm();
+            Studio.Game = game;
+            Logger.Info($"Target Game is {Studio.Game.Name}");
+            if (Studio.Game.IsUnityCN() && Studio.Game is UnityCNGame unityCnGame)
+            {
+                UnityCNManager.SetKey(unityCnGame.Key);
+            }
+            assetsManager.SpecifyUnityVersion = specifyUnityVersion.Text;
+            assetsManager.Game = Studio.Game;
+        }
+
         public void updateGame(GameType mapGame)
         {
             Game game = GameManager.GetGameByType(mapGame);

--- a/AnimeStudio.GUI/UnityCNEdit.Designer.cs
+++ b/AnimeStudio.GUI/UnityCNEdit.Designer.cs
@@ -50,13 +50,13 @@
             tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             tableLayoutPanel1.Controls.Add(tableLayoutPanel2, 0, 1);
             tableLayoutPanel1.Controls.Add(dataGridView1, 0, 0);
-            tableLayoutPanel1.Location = new System.Drawing.Point(20, 19);
-            tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            tableLayoutPanel1.Location = new System.Drawing.Point(11, 9);
+            tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             tableLayoutPanel1.RowCount = 2;
             tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 64F));
-            tableLayoutPanel1.Size = new System.Drawing.Size(1882, 1166);
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            tableLayoutPanel1.Size = new System.Drawing.Size(1013, 477);
             tableLayoutPanel1.TabIndex = 0;
             // 
             // tableLayoutPanel2
@@ -69,21 +69,21 @@
             tableLayoutPanel2.Controls.Add(cancelBtn, 0, 0);
             tableLayoutPanel2.Controls.Add(saveBtn, 2, 0);
             tableLayoutPanel2.Controls.Add(resetBtn, 1, 0);
-            tableLayoutPanel2.Location = new System.Drawing.Point(5, 1107);
-            tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            tableLayoutPanel2.Location = new System.Drawing.Point(3, 449);
+            tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             tableLayoutPanel2.Name = "tableLayoutPanel2";
             tableLayoutPanel2.RowCount = 1;
             tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            tableLayoutPanel2.Size = new System.Drawing.Size(1872, 54);
+            tableLayoutPanel2.Size = new System.Drawing.Size(1007, 26);
             tableLayoutPanel2.TabIndex = 1;
             // 
             // cancelBtn
             // 
             cancelBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            cancelBtn.Location = new System.Drawing.Point(5, 5);
-            cancelBtn.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            cancelBtn.Location = new System.Drawing.Point(3, 2);
+            cancelBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             cancelBtn.Name = "cancelBtn";
-            cancelBtn.Size = new System.Drawing.Size(613, 44);
+            cancelBtn.Size = new System.Drawing.Size(329, 22);
             cancelBtn.TabIndex = 1;
             cancelBtn.Text = "Cancel";
             cancelBtn.UseVisualStyleBackColor = false;
@@ -91,10 +91,10 @@
             // saveBtn
             // 
             saveBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            saveBtn.Location = new System.Drawing.Point(1251, 5);
-            saveBtn.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            saveBtn.Location = new System.Drawing.Point(673, 2);
+            saveBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             saveBtn.Name = "saveBtn";
-            saveBtn.Size = new System.Drawing.Size(616, 44);
+            saveBtn.Size = new System.Drawing.Size(331, 22);
             saveBtn.TabIndex = 0;
             saveBtn.Text = "Save";
             saveBtn.UseVisualStyleBackColor = false;
@@ -103,10 +103,10 @@
             // resetBtn
             // 
             resetBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            resetBtn.Location = new System.Drawing.Point(628, 5);
-            resetBtn.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            resetBtn.Location = new System.Drawing.Point(338, 2);
+            resetBtn.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             resetBtn.Name = "resetBtn";
-            resetBtn.Size = new System.Drawing.Size(613, 44);
+            resetBtn.Size = new System.Drawing.Size(329, 22);
             resetBtn.TabIndex = 2;
             resetBtn.Text = "Reset";
             resetBtn.UseVisualStyleBackColor = false;
@@ -117,11 +117,11 @@
             dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { ID, NAME, KEY });
             dataGridView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            dataGridView1.Location = new System.Drawing.Point(5, 5);
-            dataGridView1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            dataGridView1.Location = new System.Drawing.Point(3, 2);
+            dataGridView1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             dataGridView1.Name = "dataGridView1";
             dataGridView1.RowHeadersWidth = 51;
-            dataGridView1.Size = new System.Drawing.Size(1872, 1092);
+            dataGridView1.Size = new System.Drawing.Size(1007, 443);
             dataGridView1.TabIndex = 2;
             // 
             // ID
@@ -147,13 +147,13 @@
             // 
             // UnityCNEdit
             // 
-            AutoScaleDimensions = new System.Drawing.SizeF(13F, 32F);
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             CancelButton = cancelBtn;
-            ClientSize = new System.Drawing.Size(1921, 1205);
+            ClientSize = new System.Drawing.Size(1034, 497);
             Controls.Add(tableLayoutPanel1);
             Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
-            Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             Name = "UnityCNEdit";
             Text = "UnityCN Keys Editor";
             tableLayoutPanel1.ResumeLayout(false);

--- a/AnimeStudio/GameManager.cs
+++ b/AnimeStudio/GameManager.cs
@@ -83,7 +83,7 @@ namespace AnimeStudio
                 string name = entry[1];
                 string key = entry[2];
 
-                GameType type = Enum.TryParse(enumName, out GameType parsed) ? parsed : GameType.UnityCNCustomKey;
+                GameType type = Enum.TryParse(enumName, out GameType parsed) ? parsed : GameType.UnityCN;
 
                 Games.Add(index++, new UnityCNGame(type, new(name, key), GameCategory.Other));
             }


### PR DESCRIPTION
- Fixed UnityCNEdit Form buttons Save, Cancel, Reset position which was putting them outside of the window form max size
- Fixed the logic used for selecting games in `Game` dropdown menu. There were a bug for UnityCN games listed (inside CNKeys.json) or when the key was inserted manually, that was causing `updateGame()` to select always the first element of CNKeys.json for `GameType == UnityCNCustomKey`